### PR TITLE
Add custom override props for datetime formatting #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Displays a complete, interactive calendar.
 |activeStartDate|The beginning of a period that shall be displayed by default when no value is given. Defaults to today.|`new Date(2017, 0, 1)`|
 |calendarType|Defines which type of calendar should be used. Can be "US" or "ISO 8601". Defaults to "US" for "en-US" locale, "ISO 8601" to all the others.|`"ISO 8601"`|
 |className|Defines class name(s) that will be added along with "react-calendar" to the main React-Calendar `<div>` element.|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|
+|formatMonth|Function called to override default formatting of month names. Can be used to use your own formatting function|value => formatDate(value, 'MMM')|
+|formatMonthYear|Function called to override default formatting of month and year in the top navigation section. Can be used to use your own formatting function|value => formatDate(value, 'MMMM YYYY')|
+|formatDateShort|Function called to override default formatting of weekday names. Can be used to use your own formatting function|value => formatDate(value, 'dd')|
 |locale|Defines which locale should be used by the calendar. Can be any [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag). Defaults to user's browser settings.|`"hu-HU"`|
 |maxDate|Defines maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although react-calendar will ensure that no later date is selected.|Date: `new Date()`|
 |maxDetail|Defines the most detailed view that the user shall see. View defined here also becomes the one on which clicking an item will select a date and pass it to onChange. Can be "month", "year", "decade" or "century". Defaults to "month".|`"month"`|

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -291,6 +291,8 @@ export default class Calendar extends Component {
   renderContent() {
     const {
       calendarType,
+      formatMonth,
+      formatShortWeekday,
       maxDate,
       minDate,
       renderChildren,
@@ -304,6 +306,8 @@ export default class Calendar extends Component {
 
     const commonProps = {
       activeStartDate,
+      formatMonth,
+      formatShortWeekday,
       hover,
       maxDate,
       minDate,
@@ -366,6 +370,7 @@ export default class Calendar extends Component {
         activeRange={this.state.activeRange}
         activeStartDate={this.state.activeStartDate}
         drillUp={this.drillUp}
+        formatMonthYear={this.props.formatMonthYear}
         maxDate={this.props.maxDate}
         minDate={this.props.minDate}
         next2Label={this.props.next2Label}
@@ -415,6 +420,9 @@ Calendar.propTypes = {
   activeStartDate: PropTypes.instanceOf(Date),
   calendarType: isCalendarType,
   className: isClassName,
+  formatMonth: PropTypes.func,
+  formatMonthYear: PropTypes.func,
+  formatShortWeekday: PropTypes.func,
   locale: PropTypes.string,
   maxDate: isMaxDate,
   maxDetail: PropTypes.oneOf(allViews),

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -74,7 +74,7 @@ export default class Navigation extends PureComponent {
   }
 
   get label() {
-    const { activeStartDate: date, view } = this.props;
+    const { formatMonthYear, activeStartDate: date, view } = this.props;
 
     switch (view) {
       case 'century':
@@ -154,6 +154,7 @@ export default class Navigation extends PureComponent {
 }
 
 Navigation.defaultProps = {
+  formatMonthYear: formatMonthYear,
   next2Label: '»',
   nextLabel: '›',
   prev2Label: '«',
@@ -163,6 +164,7 @@ Navigation.defaultProps = {
 Navigation.propTypes = {
   activeStartDate: PropTypes.instanceOf(Date).isRequired,
   drillUp: PropTypes.func.isRequired,
+  formatMonthYear: PropTypes.func,
   maxDate: PropTypes.instanceOf(Date),
   minDate: PropTypes.instanceOf(Date),
   next2Label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/src/MonthView.jsx
+++ b/src/MonthView.jsx
@@ -26,12 +26,13 @@ export default class MonthView extends PureComponent {
 
   renderWeekdays() {
     const { calendarType } = this;
-    const { activeStartDate } = this.props;
+    const { activeStartDate, formatShortWeekday } = this.props;
 
     return (
       <Weekdays
         calendarType={calendarType}
         month={activeStartDate}
+        formatShortWeekday={formatShortWeekday}
       />
     );
   }

--- a/src/MonthView/Weekdays.jsx
+++ b/src/MonthView/Weekdays.jsx
@@ -33,7 +33,7 @@ export default class Weekdays extends PureComponent {
 
   render() {
     const { beginOfMonth, year, monthIndex } = this;
-    const { calendarType } = this.props;
+    const { calendarType, formatShortWeekday } = this.props;
 
     const weekdays = [];
 
@@ -70,4 +70,9 @@ Weekdays.propTypes = {
     PropTypes.number,
     PropTypes.instanceOf(Date),
   ]).isRequired,
+  formatShortWeekday: PropTypes.func
 };
+
+Weekdays.defaultProps = {
+  formatShortWeekday: formatShortWeekday
+}

--- a/src/YearView.jsx
+++ b/src/YearView.jsx
@@ -23,6 +23,7 @@ export default class YearView extends PureComponent {
 
 YearView.propTypes = {
   activeStartDate: PropTypes.instanceOf(Date).isRequired,
+  formatMonth: PropTypes.func,
   maxDate: isMaxDate,
   minDate: isMinDate,
   onChange: PropTypes.func,

--- a/src/YearView/Month.jsx
+++ b/src/YearView/Month.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import mergeClassNames from 'merge-class-names';
 
 import {
@@ -14,6 +15,7 @@ const className = 'react-calendar__year-view__months__month';
 const Month = ({
   classes,
   date,
+  formatMonth,
   maxDate,
   minDate,
   onClick,
@@ -47,6 +49,11 @@ const Month = ({
 
 Month.propTypes = {
   ...tileProps,
+  formatMonth: PropTypes.func,
 };
+
+Month.defaultProps = {
+  formatMonth: formatMonth,
+}
 
 export default Month;

--- a/src/__tests__/Calendar.jsx
+++ b/src/__tests__/Calendar.jsx
@@ -475,4 +475,29 @@ describe('Calendar', () => {
       view: 'year',
     });
   });
+
+  it('displays calendar with custom weekdays formatting', () => {
+    const component = mount(
+      <Calendar
+        formatShortWeekday={ () => 'Weekday'}
+      />
+    );
+
+    const monthView = component.find('.react-calendar__month-view');
+    const firstWeekdayTile = monthView.find('.react-calendar__month-view__weekdays__weekday').first();
+
+    expect(firstWeekdayTile.text()).toBe('Weekday');
+  });
+
+  it('displays calendar with custom month year navigation label', () => {
+    const component = mount(
+      <Calendar
+        formatMonthYear={ () => 'MonthYear'}
+      />
+    );
+
+    const navigationLabel = component.find('.react-calendar__navigation__label').first();
+
+    expect(navigationLabel.text()).toBe('MonthYear');
+  })
 });

--- a/src/__tests__/YearView.jsx
+++ b/src/__tests__/YearView.jsx
@@ -122,4 +122,19 @@ describe('YearView', () => {
     expect(firstDayTileContent).toHaveLength(1);
     expect(secondDayTileContent).toHaveLength(0);
   });
+
+  it('displays year view with custom month formatting', () => {
+  	const activeStartDate = new Date(2017, 0, 1);
+
+    const component = mount(
+      <YearView
+        activeStartDate={activeStartDate}
+        formatMonth={() => 'Month'}
+      />
+    );
+
+    const month = component.find('.react-calendar__year-view__months__month').first();
+
+    expect(month.text()).toBe('Month');
+  })
 });


### PR DESCRIPTION
I implemented custom overrides for all three types of dateTime formatting that involved, months or weekday names. Others overrides should not be required. 

This change allows for users to use their own date formatting library instead of relying on browser implementation that is broken for some languages in some browsers.