### PR TITLE
Add --today class, renderLabel prop, clarify calendarTypes docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Displays a complete, interactive calendar.
 |Prop name|Description|Example values|
 |----|----|----|
 |activeStartDate|The beginning of a period that shall be displayed by default when no value is given. Defaults to today.|`new Date(2017, 0, 1)`|
-|calendarType|Defines which type of calendar should be used. Can be "US" or "ISO 8601". Defaults to "US" for "en-US" locale, "ISO 8601" to all the others.|`"ISO 8601"`|
+|calendarType|Defines which type of calendar should be used. Can be "US" or "ISO 8601". Defaults to "US" for "en-US" locale, "ISO 8601" to all the others. Changing to "US" will change the first day of the week from Monday to Sunday.|`"ISO 8601"`|
 |className|Defines class name(s) that will be added along with "react-calendar" to the main React-Calendar `<div>` element.|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|
 |formatMonth|Function called to override default formatting of month names. Can be used to use your own formatting function.|`(value) => formatDate(value, 'MMM')`|
 |formatMonthYear|Function called to override default formatting of month and year in the top navigation section. Can be used to use your own formatting function.|`(value) => formatDate(value, 'MMMM YYYY')`|

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -367,6 +367,7 @@ export default class Calendar extends Component {
         nextLabel={this.props.nextLabel}
         prev2Label={this.props.prev2Label}
         prevLabel={this.props.prevLabel}
+        renderLabel={this.props.renderLabel}
         setActiveStartDate={this.setActiveStartDate}
         view={this.state.view}
         views={this.getLimitedViews()}
@@ -404,6 +405,7 @@ Calendar.defaultProps = {
   showNavigation: true,
   showNeighboringMonth: true,
   view: 'month',
+  renderLabel: label => label,
 };
 
 Calendar.propTypes = {
@@ -431,6 +433,7 @@ Calendar.propTypes = {
   onDrillUp: PropTypes.func,
   prev2Label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   prevLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  renderLabel: PropTypes.func,
   renderChildren: PropTypes.func, // For backwards compatibility
   returnValue: PropTypes.oneOf(['start', 'end', 'range']),
   selectRange: PropTypes.bool,

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -82,18 +82,18 @@ export default class Navigation extends Component {
 
   get label() {
     const {
-      activeStartDate: date, formatMonthYear, locale, view,
+      activeStartDate: date, formatMonthYear, locale, view, renderLabel
     } = this.props;
 
     switch (view) {
       case 'century':
-        return getCenturyLabel(date);
+        return renderLabel(getCenturyLabel(date));
       case 'decade':
-        return getDecadeLabel(date);
+        return renderLabel(getDecadeLabel(date));
       case 'year':
-        return getYear(date);
+        return renderLabel(getYear(date));
       case 'month':
-        return formatMonthYear(date, locale);
+        return renderLabel(formatMonthYear(date, locale));
       default:
         throw new Error(`Invalid view: ${view}.`);
     }

--- a/src/MonthView/Day.jsx
+++ b/src/MonthView/Day.jsx
@@ -27,6 +27,7 @@ const Day = ({
       className,
       isWeekend(date) ? `${className}--weekend` : null,
       date.getMonth() !== currentMonthIndex ? `${className}--neighboringMonth` : null,
+      getISOLocalDate(date) === getISOLocalDate(new Date()) ? 'react-calendar__tile--today' : null,
     ]}
     date={date}
     dateTime={`${getISOLocalDate(date)}T00:00:00.000`}


### PR DESCRIPTION
These are some things I needed for a project I'm working on. I needed to be able to style today's date differently to other dates and render something next to the navigation label. 

Also, I struggled for a while trying to find how to change the first day of the week from Monday to Sunday. I was planning on adding that functionality as well, but then noticed it was in the calendarType prop. So I clarified that changing to "US" would do that in the docs.