### PR TITLE
Add today class

### DIFF
--- a/src/MonthView/Day.jsx
+++ b/src/MonthView/Day.jsx
@@ -27,6 +27,7 @@ const Day = ({
       className,
       isWeekend(date) ? `${className}--weekend` : null,
       date.getMonth() !== currentMonthIndex ? `${className}--neighboringMonth` : null,
+      date.toDateString() === new Date().toDateString() ? 'react-calendar__tile--today' : null,
     ]}
     date={date}
     dateTime={`${getISOLocalDate(date)}T00:00:00.000`}


### PR DESCRIPTION
Sorry If I'm missing something with this one.`.getTime()` for `new Date()` would include the hours/minutes/seconds whereas `date` does not, so they wouldn't be equal, right? Figured `toDateString` would be the easiest comparison?