### PR TITLE
onActiveDateChange not working (to support with < 0.15 versions) #61

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "react-dom": "^16.3.0"
   },
   "peerDependencies": {
-    "react": ">=15.5",
-    "react-dom": ">=15.5"
+    "react": ">=14.9",
+    "react-dom": ">=14.9"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build-styles": "lessc ./dist/Calendar.less ./dist/Calendar.css",
     "copy-styles": "node ./copy-styles.js",
     "prepublishOnly": "npm run build",
+    "postinstall": "npm run build",
     "test": "npm run test-eslint && npm run test-jest",
     "test-eslint": "eslint ./src",
     "test-jest": "jest",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build-styles": "lessc ./dist/Calendar.less ./dist/Calendar.css",
     "copy-styles": "node ./copy-styles.js",
     "prepublishOnly": "npm run build",
-    "postinstall": "npm run build",
+    "postinstall": "postinstall-build build",
     "test": "npm run test-eslint && npm run test-jest",
     "test-eslint": "eslint ./src",
     "test-jest": "jest",
@@ -54,6 +54,7 @@
   "dependencies": {
     "lodash.once": "^4.1.1",
     "merge-class-names": "^1.1.1",
+    "postinstall-build": "^5.0.1",
     "prop-types": "^15.6.0",
     "react-lifecycles-compat": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
     "LICENSE",
     "README.md",
     "index.d.ts",
+    "copy-styles.js",
+    "copy-styles.js",
     "dist/",
     "src/"
   ],

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import polyfill from 'react-lifecycles-compat';
 import mergeClassNames from 'merge-class-names';
@@ -65,7 +66,7 @@ const getValueFrom = (value, minDate, maxDate, maxDetail) => {
   const valueFromDate = new Date(rawValueFrom);
 
   if (isNaN(valueFromDate.getTime())) {
-    throw new Error(`Invalid date: ${value}`);
+    throw new Error(`Invalid date:$ {value}`);
   }
 
   const valueFrom = getBegin(getValueType(maxDetail), valueFromDate);
@@ -111,8 +112,7 @@ const getActiveStartDate = (props) => {
   const valueFrom = (
     getValueFrom(props.value, props.minDate, props.maxDate, props.maxDetail) ||
     props.activeStartDate ||
-    new Date()
-  );
+    new Date());
   return getBegin(rangeType, valueFrom);
 };
 
@@ -180,8 +180,7 @@ export default class Calendar extends Component {
     if (
       nextState.view || // Allowed view changed
       datesAreDifferent(...values.map(value => getValueFrom(value, minDate, maxDate, maxDetail))) ||
-      datesAreDifferent(...values.map(value => getValueTo(value, minDate, maxDate, maxDetail)))
-    ) {
+      datesAreDifferent(...values.map(value => getValueTo(value, minDate, maxDate, maxDetail)))) {
       nextState.value = nextProps.value;
     }
 
@@ -198,12 +197,10 @@ export default class Calendar extends Component {
    * Called when the user uses navigation buttons.
    */
   setActiveStartDate = (activeStartDate) => {
-    this.setState({ activeStartDate }, () => {
-      callIfDefined(this.props.onActiveDateChange, {
-        activeStartDate,
-        view: this.state.view,
-      });
-    });
+    this.setState({ activeStartDate }, () => callIfDefined(this.props.onActiveDateChange, {
+      activeStartDate,
+      view: this.state.view,
+    }));
   }
 
   drillDown = (activeStartDate) => {
@@ -219,12 +216,10 @@ export default class Calendar extends Component {
         activeStartDate,
         view: nextView,
       };
-    }, () => {
-      callIfDefined(this.props.onDrillDown, {
-        activeStartDate,
-        view: this.state.view,
-      });
-    });
+    }, () => callIfDefined(this.props.onDrillDown, {
+      activeStartDate,
+      view: this.state.view,
+    }));
   }
 
   drillUp = () => {
@@ -242,12 +237,10 @@ export default class Calendar extends Component {
         activeStartDate,
         view: nextView,
       };
-    }, () => {
-      callIfDefined(this.props.onDrillUp, {
-        activeStartDate: this.state.activeStartDate,
-        view: this.state.view,
-      });
-    });
+    }, () => callIfDefined(this.props.onDrillUp, {
+      activeStartDate: this.state.activeStartDate,
+      view: this.state.view,
+    }));
   }
 
   onChange = (value) => {
@@ -258,21 +251,19 @@ export default class Calendar extends Component {
     if (selectRange) {
       const { value: previousValue } = this.state;
       // Range selection turned on
-      if (
-        !previousValue ||
-        [].concat(previousValue).length !== 1 // 0 or 2 - either way we're starting a new array
+      if (!previousValue || [].concat(previousValue).length !== 1 // 0 or 2 - either way we're starting a new array
       ) {
         // First value
         nextValue = getBegin(this.valueType, value);
       } else {
         // Second value
         nextValue = getValueRange(this.valueType, previousValue, value);
-        callback = () => callIfDefined(onChange, nextValue);
+        callback = callIfDefined(onChange, nextValue);
       }
     } else {
       // Range selection turned off
       nextValue = this.getProcessedValue(value);
-      callback = () => callIfDefined(onChange, nextValue);
+      callback = callIfDefined(onChange, nextValue);
     }
 
     this.setState({ value: nextValue }, callback);
@@ -298,10 +289,12 @@ export default class Calendar extends Component {
       tileDisabled,
     } = this.props;
     const {
-      activeStartDate, hover, value, view,
+      activeStartDate,
+      hover,
+      value,
     } = this.state;
     const { onMouseOver, valueType } = this;
-
+    const view = this.state.view || this.props.view;
     const commonProps = {
       activeStartDate,
       hover,
@@ -322,36 +315,36 @@ export default class Calendar extends Component {
       case 'century':
         return (
           <CenturyView
-            onClick={mergeFunctions(clickAction, this.props.onClickDecade)}
-            {...commonProps}
-          />
+                        onClick={mergeFunctions(clickAction, this.props.onClickDecade)}
+                        {...commonProps}
+                    />
         );
       case 'decade':
         return (
           <DecadeView
-            onClick={mergeFunctions(clickAction, this.props.onClickYear)}
-            {...commonProps}
-          />
+                        onClick={mergeFunctions(clickAction, this.props.onClickYear)}
+                        {...commonProps}
+                    />
         );
       case 'year':
         return (
           <YearView
-            formatMonth={this.props.formatMonth}
-            onClick={mergeFunctions(clickAction, this.props.onClickMonth)}
-            {...commonProps}
-          />
+                        formatMonth={this.props.formatMonth}
+                        onClick={mergeFunctions(clickAction, this.props.onClickMonth)}
+                        {...commonProps}
+                    />
         );
       case 'month':
         return (
           <MonthView
-            calendarType={calendarType}
-            formatShortWeekday={this.props.formatShortWeekday}
-            onClick={mergeFunctions(clickAction, this.props.onClickDay)}
-            onClickWeekNumber={this.props.onClickWeekNumber}
-            showNeighboringMonth={this.props.showNeighboringMonth}
-            showWeekNumbers={this.props.showWeekNumbers}
-            {...commonProps}
-          />
+                        calendarType={calendarType}
+                        formatShortWeekday={this.props.formatShortWeekday}
+                        onClick={mergeFunctions(clickAction, this.props.onClickDay)}
+                        onClickWeekNumber={this.props.onClickWeekNumber}
+                        showNeighboringMonth={this.props.showNeighboringMonth}
+                        showWeekNumbers={this.props.showWeekNumbers}
+                        {...commonProps}
+                    />
         );
       default:
         throw new Error(`Invalid view: ${view}.`);
@@ -466,4 +459,6 @@ Calendar.propTypes = {
   view: PropTypes.oneOf(allViews),
 };
 
-polyfill(Calendar);
+if (polyfill) {
+  polyfill(Calendar);
+}

--- a/src/CenturyView.jsx
+++ b/src/CenturyView.jsx
@@ -1,11 +1,11 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import Decades from './CenturyView/Decades';
 
 import { isMaxDate, isMinDate, isValue } from './shared/propTypes';
 
-export default class CenturyView extends PureComponent {
+export default class CenturyView extends Component {
   renderDecades() {
     return (
       <Decades {...this.props} />

--- a/src/CenturyView/Decades.jsx
+++ b/src/CenturyView/Decades.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 
 import TileGroup from '../TileGroup';
 import Decade from './Decade';
@@ -9,7 +9,7 @@ import {
 } from '../shared/dates';
 import { tileGroupProps } from '../shared/propTypes';
 
-export default class Decades extends PureComponent {
+export default class Decades extends Component {
   get start() {
     const { activeStartDate } = this.props;
     return getBeginOfCenturyYear(activeStartDate);

--- a/src/DecadeView.jsx
+++ b/src/DecadeView.jsx
@@ -1,11 +1,11 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import Years from './DecadeView/Years';
 
 import { isMaxDate, isMinDate, isValue } from './shared/propTypes';
 
-export default class DecadeView extends PureComponent {
+export default class DecadeView extends Component {
   renderYears() {
     return (
       <Years {...this.props} />

--- a/src/DecadeView/Years.jsx
+++ b/src/DecadeView/Years.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 
 import TileGroup from '../TileGroup';
 import Year from './Year';
@@ -6,7 +6,7 @@ import Year from './Year';
 import { getBeginOfDecadeYear } from '../shared/dates';
 import { tileGroupProps } from '../shared/propTypes';
 
-export default class Years extends PureComponent {
+export default class Years extends Component {
   get start() {
     const { activeStartDate } = this.props;
     return getBeginOfDecadeYear(activeStartDate);

--- a/src/MonthView.jsx
+++ b/src/MonthView.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import Days from './MonthView/Days';
@@ -7,7 +7,7 @@ import WeekNumbers from './MonthView/WeekNumbers';
 
 import { isCalendarType, isMaxDate, isMinDate, isValue } from './shared/propTypes';
 
-export default class MonthView extends PureComponent {
+export default class MonthView extends Component {
   get calendarType() {
     const { calendarType, locale } = this.props;
 

--- a/src/MonthView/Days.jsx
+++ b/src/MonthView/Days.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TileGroup from '../TileGroup';
@@ -12,7 +12,7 @@ import {
 } from '../shared/dates';
 import { isCalendarType, tileGroupProps } from '../shared/propTypes';
 
-export default class Days extends PureComponent {
+export default class Days extends Component {
   get offset() {
     if (this.props.showNeighboringMonth) {
       return 0;

--- a/src/MonthView/WeekNumbers.jsx
+++ b/src/MonthView/WeekNumbers.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import WeekNumber from './WeekNumber';
@@ -15,7 +15,7 @@ import {
 } from '../shared/dates';
 import { isCalendarType } from '../shared/propTypes';
 
-export default class WeekNumbers extends PureComponent {
+export default class WeekNumbers extends Component {
   get startWeekday() {
     const { activeStartDate, calendarType } = this.props;
     return getDayOfWeek(activeStartDate, calendarType);

--- a/src/YearView.jsx
+++ b/src/YearView.jsx
@@ -1,11 +1,11 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import Months from './YearView/Months';
 
 import { isMaxDate, isMinDate, isValue } from './shared/propTypes';
 
-export default class YearView extends PureComponent {
+export default class YearView extends Component {
   renderMonths() {
     return (
       <Months {...this.props} />

--- a/src/YearView/Months.jsx
+++ b/src/YearView/Months.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TileGroup from '../TileGroup';
@@ -7,7 +7,7 @@ import Month from './Month';
 import { getYear } from '../shared/dates';
 import { tileGroupProps } from '../shared/propTypes';
 
-export default class Months extends PureComponent {
+export default class Months extends Component {
   start = 0
 
   end = 11


### PR DESCRIPTION
Hi Wojtek, I figured out the root cause of my problem.
1. My current react-calender is version 2.13.
2. It seems that the callIfDefined was not working in 2.13 because of the arrow function. The arrow function callback hides the callIfDefined function object. There is a possibility that the arrow function was only called but not the actual callIfDefined (there would be cases that it wasnt attached at the dist copy)
3. My application is using 0.14 react version. When I tried to upgrade to 2.14 PureComponents produces error, (missing in React 0.14.9).  
My solutions
1.  I changed all PureComponents into Components 
2.  I made all the callback arrow functions to return callIfDefined function object.
3. I upgraded my version to react-calendar 2.14