### PR TITLE
Adds navigationLabel prop in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ declare module "react-calendar" {
     maxDetail?: Detail;
     minDate?: Date;
     minDetail?: Detail;
+    navigationLabel?: ({date: Date, view: Detail, label: string}) => string | JSX.Element | null;
     next2Label?: string | JSX.Element | null;
     nextLabel?: string | JSX.Element;
     onActiveDateChange?: ViewCallback;


### PR DESCRIPTION
Using TypeScript, a compilation error occurs when trying to use `navigationLabel` prop on Calendar.