### PR TITLE
Fixes warning about activeStartDate required prop

### DIFF
--- a/src/CenturyView/Decades.jsx
+++ b/src/CenturyView/Decades.jsx
@@ -21,7 +21,6 @@ export default class Decades extends PureComponent {
 
   render() {
     const {
-      activeStartDate,
       ...otherProps
     } = this.props;
 

--- a/src/DecadeView/Years.jsx
+++ b/src/DecadeView/Years.jsx
@@ -18,7 +18,6 @@ export default class Years extends PureComponent {
 
   render() {
     const {
-      activeStartDate,
       ...otherProps
     } = this.props;
 

--- a/src/YearView/Months.jsx
+++ b/src/YearView/Months.jsx
@@ -19,7 +19,6 @@ export default class Months extends PureComponent {
 
   render() {
     const {
-      activeStartDate,
       ...otherProps
     } = this.props;
 

--- a/src/shared/propTypes.js
+++ b/src/shared/propTypes.js
@@ -99,7 +99,7 @@ export const tileGroupProps = {
 };
 
 export const tileProps = {
-  activeStartDate: PropTypes.instanceOf(Date),
+  activeStartDate: PropTypes.instanceOf(Date).isRequired,
   classes: PropTypes.arrayOf(PropTypes.string).isRequired,
   date: PropTypes.instanceOf(Date).isRequired,
   maxDate: isMaxDate,

--- a/src/shared/propTypes.js
+++ b/src/shared/propTypes.js
@@ -99,7 +99,7 @@ export const tileGroupProps = {
 };
 
 export const tileProps = {
-  activeStartDate: PropTypes.instanceOf(Date).isRequired,
+  activeStartDate: PropTypes.instanceOf(Date),
   classes: PropTypes.arrayOf(PropTypes.string).isRequired,
   date: PropTypes.instanceOf(Date).isRequired,
   maxDate: isMaxDate,


### PR DESCRIPTION
I realised I introduced a warning by making the prop as required, my bad.

Also, do you think you can publish a new version of the package after this merge?
Thank you!