### PR TITLE
Fix navigation label typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ declare module "react-calendar" {
     maxDetail?: Detail;
     minDate?: Date;
     minDetail?: Detail;
-    navigationLabel?: ({date: Date, view: Detail, label: string}) => string | JSX.Element | null;
+    navigationLabel?: (props: { date: Date, view: Detail, label: string }) => string | JSX.Element | null;
     next2Label?: string | JSX.Element | null;
     nextLabel?: string | JSX.Element;
     onActiveDateChange?: ViewCallback;


### PR DESCRIPTION
This PR is a fix for the TypeScript definitions issue.

Version of `react-calendar` we have: 2.17.2

<img width="493" alt="image" src="https://user-images.githubusercontent.com/918065/45364557-be007880-b5da-11e8-955d-5543bc08fb53.png">

Our tsconfig.json contains `strict: true` and `noImplicitAny: true`

We got a problem while compiling in strict mode saying that String is typed as any. But actually that seem to be wrong syntax (in JS that syntax used for object destructuring). Here is [some short explanation](https://blog.mariusschulz.com/2015/11/13/typing-destructured-object-parameters-in-typescript) i found online

You could compare what was before and after [here](https://agentcooper.github.io/typescript-play/#code/C4TwDgpgBA6gTgewHYHMoF4oAoDeUAWEANkQgFxQDKwcAlqlAL4CUGAfFAM430oDcAKFCQoAYQRw4EAMbAM2MIjCcKeQiXJceDFuy11UggdOTcoAd0SoK8ZGky4CxUk1boO60nygB6H040CAENOKGFoACIgpBAI41M5E0kZYApxZNl5R08EVz0c7z8Al3wQsPBI7gMUCKA)

seems like it was caused by #107 