### PR TITLE
Optimize syntax to create minimal Babel output

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -180,16 +180,20 @@ export default class Calendar extends Component {
       minDate, maxDate, maxDetail, returnValue,
     } = this.props;
 
-    switch (returnValue) {
-      case 'start':
-        return getDetailValueFrom(value, minDate, maxDate, maxDetail);
-      case 'end':
-        return getDetailValueTo(value, minDate, maxDate, maxDetail);
-      case 'range':
-        return getDetailValueArray(value, minDate, maxDate, maxDetail);
-      default:
-        throw new Error('Invalid returnValue.');
-    }
+    const processFunction = (() => {
+      switch (returnValue) {
+        case 'start':
+          return getDetailValueFrom;
+        case 'end':
+          return getDetailValueTo;
+        case 'range':
+          return getDetailValueArray;
+        default:
+          throw new Error('Invalid returnValue.');
+      }
+    })();
+
+    return processFunction(value, minDate, maxDate, maxDetail);
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -15,69 +15,73 @@ import {
 import { formatMonthYear as defaultFormatMonthYear } from '../shared/dateFormatter';
 import { isView, isViews } from '../shared/propTypes';
 
-export default class Navigation extends PureComponent {
-  get drillUpAvailable() {
-    const { view, views } = this.props;
-    return views.indexOf(view) > 0;
-  }
+const className = 'react-calendar__navigation';
 
-  get prevButtonDisabled() {
-    const { activeStartDate: date, minDate, view } = this.props;
-    const previousActiveStartDate = getBeginPrevious(view, date);
+export default function Navigation({
+  activeStartDate: date,
+  drillUp,
+  formatMonthYear,
+  locale,
+  maxDate,
+  minDate,
+  navigationLabel,
+  next2Label,
+  nextLabel,
+  prev2Label,
+  prevLabel,
+  setActiveStartDate,
+  view,
+  views,
+}) {
+  const drillUpAvailable = views.indexOf(view) > 0;
+  const shouldShowPrevNext2Buttons = view !== 'century';
+
+  const previousActiveStartDate = getBeginPrevious(view, date);
+  const previousActiveStartDate2 = shouldShowPrevNext2Buttons && getBeginPrevious2(view, date);
+  const nextActiveStartDate = getBeginNext(view, date);
+  const nextActiveStartDate2 = shouldShowPrevNext2Buttons && getBeginNext2(view, date);
+
+  const prevButtonDisabled = (() => {
     if (previousActiveStartDate.getFullYear() < 1000) {
       return true;
     }
     const previousActiveEndDate = getEndPrevious(view, date);
     return minDate && minDate >= previousActiveEndDate;
-  }
+  })();
 
-  get prev2ButtonDisabled() {
-    const { activeStartDate: date, minDate, view } = this.props;
-    const previousActiveStartDate = getBeginPrevious2(view, date);
-    if (previousActiveStartDate.getFullYear() < 1000) {
+  const prev2ButtonDisabled = shouldShowPrevNext2Buttons && (() => {
+    if (previousActiveStartDate2.getFullYear() < 1000) {
       return true;
     }
     const previousActiveEndDate = getEndPrevious2(view, date);
     return minDate && minDate >= previousActiveEndDate;
+  })();
+
+  const nextButtonDisabled = maxDate && maxDate <= nextActiveStartDate;
+
+  const next2ButtonDisabled = (
+    shouldShowPrevNext2Buttons
+    && maxDate
+    && maxDate <= nextActiveStartDate2
+  );
+
+  function onClickPrevious() {
+    setActiveStartDate(previousActiveStartDate);
   }
 
-  get nextButtonDisabled() {
-    const { activeStartDate: date, maxDate, view } = this.props;
-    const nextActiveStartDate = getBeginNext(view, date);
-    return maxDate && maxDate <= nextActiveStartDate;
+  function onClickPrevious2() {
+    setActiveStartDate(previousActiveStartDate2);
   }
 
-  get next2ButtonDisabled() {
-    const { activeStartDate: date, maxDate, view } = this.props;
-    const nextActiveStartDate = getBeginNext2(view, date);
-    return maxDate && maxDate <= nextActiveStartDate;
+  function onClickNext() {
+    setActiveStartDate(nextActiveStartDate);
   }
 
-  onClickPrevious = () => {
-    const { activeStartDate: date, view, setActiveStartDate } = this.props;
-    setActiveStartDate(getBeginPrevious(view, date));
+  function onClickNext2() {
+    setActiveStartDate(nextActiveStartDate2);
   }
 
-  onClickNext = () => {
-    const { activeStartDate: date, view, setActiveStartDate } = this.props;
-    setActiveStartDate(getBeginNext(view, date));
-  }
-
-  onClickPrevious2 = () => {
-    const { activeStartDate: date, view, setActiveStartDate } = this.props;
-    setActiveStartDate(getBeginPrevious2(view, date));
-  }
-
-  onClickNext2 = () => {
-    const { activeStartDate: date, view, setActiveStartDate } = this.props;
-    setActiveStartDate(getBeginNext2(view, date));
-  }
-
-  get label() {
-    const {
-      activeStartDate: date, formatMonthYear, locale, view,
-    } = this.props;
-
+  const label = (() => {
     switch (view) {
       case 'century':
         return getCenturyLabel(date);
@@ -90,79 +94,63 @@ export default class Navigation extends PureComponent {
       default:
         throw new Error(`Invalid view: ${view}.`);
     }
-  }
+  })();
 
-  render() {
-    const { label } = this;
-    const {
-      activeStartDate: date,
-      drillUp,
-      navigationLabel,
-      next2Label,
-      nextLabel,
-      prev2Label,
-      prevLabel,
-      view,
-    } = this.props;
-
-    const className = 'react-calendar__navigation';
-
-    return (
-      <div
-        className={className}
-        style={{ display: 'flex' }}
+  return (
+    <div
+      className={className}
+      style={{ display: 'flex' }}
+    >
+      {prev2Label !== null && shouldShowPrevNext2Buttons && (
+        <button
+          className={`${className}__arrow ${className}__prev2-button`}
+          disabled={prev2ButtonDisabled}
+          onClick={onClickPrevious2}
+          type="button"
+        >
+          {prev2Label}
+        </button>
+      )}
+      <button
+        className={`${className}__arrow ${className}__prev-button`}
+        disabled={prevButtonDisabled}
+        onClick={onClickPrevious}
+        type="button"
       >
-        {prev2Label !== null && view !== 'century' && (
-          <button
-            className={`${className}__arrow ${className}__prev2-button`}
-            disabled={this.prev2ButtonDisabled}
-            onClick={this.onClickPrevious2}
-            type="button"
-          >
-            {prev2Label}
-          </button>
-        )}
+        {prevLabel}
+      </button>
+      <button
+        className="react-calendar__navigation__label"
+        onClick={drillUp}
+        disabled={!drillUpAvailable}
+        style={{ flexGrow: 1 }}
+        type="button"
+      >
+        {navigationLabel
+          ? navigationLabel({ date, view, label })
+          : label
+        }
+      </button>
+      <button
+        className={`${className}__arrow ${className}__next-button`}
+        disabled={nextButtonDisabled}
+        onClick={onClickNext}
+        type="button"
+      >
+        {nextLabel}
+      </button>
+      {next2Label !== null && shouldShowPrevNext2Buttons && (
         <button
-          className={`${className}__arrow ${className}__prev-button`}
-          disabled={this.prevButtonDisabled}
-          onClick={this.onClickPrevious}
+          className={`${className}__arrow ${className}__next2-button`}
+          disabled={next2ButtonDisabled}
+          onClick={onClickNext2}
           type="button"
         >
-          {prevLabel}
+          {next2Label}
         </button>
-        <button
-          className="react-calendar__navigation__label"
-          onClick={drillUp}
-          disabled={!this.drillUpAvailable}
-          style={{ flexGrow: 1 }}
-          type="button"
-        >
-          {navigationLabel
-            ? navigationLabel({ date, view, label })
-            : label
-          }
-        </button>
-        <button
-          className={`${className}__arrow ${className}__next-button`}
-          disabled={this.nextButtonDisabled}
-          onClick={this.onClickNext}
-          type="button"
-        >
-          {nextLabel}
-        </button>
-        {next2Label !== null && view !== 'century' && (
-          <button
-            className={`${className}__arrow ${className}__next2-button`}
-            disabled={this.next2ButtonDisabled}
-            onClick={this.onClickNext2}
-            type="button"
-          >
-            {next2Label}
-          </button>
-        )}
-      </div>
-    );
-  }
+      )}
+    </div>
+  );
 }
 
 Navigation.defaultProps = {

--- a/src/CenturyView/Decade.jsx
+++ b/src/CenturyView/Decade.jsx
@@ -8,21 +8,21 @@ import { tileProps } from '../shared/propTypes';
 
 const className = 'react-calendar__century-view__decades__decade';
 
-const Decade = ({ classes, point, ...otherProps }) => (
-  <Tile
-    {...otherProps}
-    classes={[...classes, className]}
-    maxDateTransform={getEndOfDecade}
-    minDateTransform={getBeginOfDecade}
-    view="century"
-  >
-    {getDecadeLabel(point)}
-  </Tile>
-);
+export default function Decade({ classes, point, ...otherProps }) {
+  return (
+    <Tile
+      {...otherProps}
+      classes={[].concat(classes, className)}
+      maxDateTransform={getEndOfDecade}
+      minDateTransform={getBeginOfDecade}
+      view="century"
+    >
+      {getDecadeLabel(point)}
+    </Tile>
+  );
+}
 
 Decade.propTypes = {
   ...tileProps,
   point: PropTypes.number.isRequired,
 };
-
-export default Decade;

--- a/src/CenturyView/Decades.jsx
+++ b/src/CenturyView/Decades.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 
 import TileGroup from '../TileGroup';
 import Decade from './Decade';
@@ -9,30 +9,23 @@ import {
 } from '../shared/dates';
 import { tileGroupProps } from '../shared/propTypes';
 
-export default class Decades extends PureComponent {
-  get start() {
-    const { activeStartDate } = this.props;
-    return getBeginOfCenturyYear(activeStartDate);
-  }
+export default function Decades(props) {
+  const { activeStartDate } = props;
+  const start = getBeginOfCenturyYear(activeStartDate);
+  const end = start + 99;
 
-  get end() {
-    return this.start + 99;
-  }
-
-  render() {
-    return (
-      <TileGroup
-        {...this.props}
-        className="react-calendar__century-view__decades"
-        dateTransform={getBeginOfDecade}
-        dateType="decade"
-        end={this.end}
-        start={this.start}
-        step={10}
-        tile={Decade}
-      />
-    );
-  }
+  return (
+    <TileGroup
+      {...props}
+      className="react-calendar__century-view__decades"
+      dateTransform={getBeginOfDecade}
+      dateType="decade"
+      end={end}
+      start={start}
+      step={10}
+      tile={Decade}
+    />
+  );
 }
 
 Decades.propTypes = {

--- a/src/DecadeView/Year.jsx
+++ b/src/DecadeView/Year.jsx
@@ -8,21 +8,21 @@ import { tileProps } from '../shared/propTypes';
 
 const className = 'react-calendar__decade-view__years__year';
 
-const Year = ({ classes, point, ...otherProps }) => (
-  <Tile
-    {...otherProps}
-    classes={[...classes, className]}
-    maxDateTransform={getEndOfYear}
-    minDateTransform={getBeginOfYear}
-    view="decade"
-  >
-    {point}
-  </Tile>
-);
+export default function Year({ classes, point, ...otherProps }) {
+  return (
+    <Tile
+      {...otherProps}
+      classes={[].concat(classes, className)}
+      maxDateTransform={getEndOfYear}
+      minDateTransform={getBeginOfYear}
+      view="decade"
+    >
+      {point}
+    </Tile>
+  );
+}
 
 Year.propTypes = {
   ...tileProps,
   point: PropTypes.number.isRequired,
 };
-
-export default Year;

--- a/src/DecadeView/Years.jsx
+++ b/src/DecadeView/Years.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 
 import TileGroup from '../TileGroup';
 import Year from './Year';
@@ -6,29 +6,22 @@ import Year from './Year';
 import { getBeginOfDecadeYear } from '../shared/dates';
 import { tileGroupProps } from '../shared/propTypes';
 
-export default class Years extends PureComponent {
-  get start() {
-    const { activeStartDate } = this.props;
-    return getBeginOfDecadeYear(activeStartDate);
-  }
+export default function Years(props) {
+  const { activeStartDate } = props;
+  const start = getBeginOfDecadeYear(activeStartDate);
+  const end = start + 9;
 
-  get end() {
-    return this.start + 9;
-  }
-
-  render() {
-    return (
-      <TileGroup
-        {...this.props}
-        className="react-calendar__decade-view__years"
-        dateTransform={year => new Date(year, 0, 1)}
-        dateType="year"
-        end={this.end}
-        start={this.start}
-        tile={Year}
-      />
-    );
-  }
+  return (
+    <TileGroup
+      {...props}
+      className="react-calendar__decade-view__years"
+      dateTransform={year => new Date(year, 0, 1)}
+      dateType="year"
+      end={end}
+      start={start}
+      tile={Year}
+    />
+  );
 }
 
 Years.propTypes = {

--- a/src/Flex.jsx
+++ b/src/Flex.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const toPercent = num => `${num}%`;
+function toPercent(num) {
+  return `${num}%`;
+}
 
-const Flex = ({
+export default function Flex({
   children,
   className,
   direction,
@@ -12,33 +14,35 @@ const Flex = ({
   style,
   wrap,
   ...otherProps
-}) => (
-  <div
-    className={className}
-    style={{
-      display: 'flex',
-      flexDirection: direction,
-      flexWrap: wrap ? 'wrap' : 'no-wrap',
-      ...style,
-    }}
-    {...otherProps}
-  >
-    {React.Children.map(children, (child, index) => (
-      React.cloneElement(
-        child,
-        {
-          ...child.props,
-          style: {
-            flexBasis: toPercent(100 / count),
-            maxWidth: toPercent(100 / count),
-            overflow: 'hidden',
-            marginLeft: offset && (index === 0) ? toPercent((100 * offset) / count) : null,
+}) {
+  return (
+    <div
+      className={className}
+      style={{
+        display: 'flex',
+        flexDirection: direction,
+        flexWrap: wrap ? 'wrap' : 'no-wrap',
+        ...style,
+      }}
+      {...otherProps}
+    >
+      {React.Children.map(children, (child, index) => (
+        React.cloneElement(
+          child,
+          {
+            ...child.props,
+            style: {
+              flexBasis: toPercent(100 / count),
+              maxWidth: toPercent(100 / count),
+              overflow: 'hidden',
+              marginLeft: offset && (index === 0) ? toPercent((100 * offset) / count) : null,
+            },
           },
-        },
-      )
-    ))}
-  </div>
-);
+        )
+      ))}
+    </div>
+  );
+}
 
 Flex.propTypes = {
   children: PropTypes.node,
@@ -52,5 +56,3 @@ Flex.propTypes = {
   ])),
   wrap: PropTypes.bool,
 };
-
-export default Flex;

--- a/src/MonthView.jsx
+++ b/src/MonthView.jsx
@@ -71,13 +71,12 @@ export default class MonthView extends PureComponent {
   }
 
   renderWeekdays() {
-    const { activeStartDate, formatShortWeekday, locale } = this.props;
+    const { formatShortWeekday, locale } = this.props;
 
     return (
       <Weekdays
         calendarType={this.calendarType}
         locale={locale}
-        activeStartDate={activeStartDate}
         formatShortWeekday={formatShortWeekday}
       />
     );

--- a/src/MonthView/Day.jsx
+++ b/src/MonthView/Day.jsx
@@ -14,34 +14,34 @@ import { tileProps } from '../shared/propTypes';
 
 const className = 'react-calendar__month-view__days__day';
 
-const Day = ({
+export default function Day({
   calendarType,
   classes,
   currentMonthIndex,
   date,
   ...otherProps
-}) => (
-  <Tile
-    {...otherProps}
-    classes={[
-      ...classes,
-      className,
-      isWeekend(date, calendarType) ? `${className}--weekend` : null,
-      date.getMonth() !== currentMonthIndex ? `${className}--neighboringMonth` : null,
-    ]}
-    date={date}
-    formatAbbr={formatLongDate}
-    maxDateTransform={getEndOfDay}
-    minDateTransform={getBeginOfDay}
-    view="month"
-  >
-    {getDay(date)}
-  </Tile>
-);
+}) {
+  return (
+    <Tile
+      {...otherProps}
+      classes={[].concat(
+        classes,
+        className,
+        isWeekend(date, calendarType) ? `${className}--weekend` : null,
+        date.getMonth() !== currentMonthIndex ? `${className}--neighboringMonth` : null,
+      )}
+      date={date}
+      formatAbbr={formatLongDate}
+      maxDateTransform={getEndOfDay}
+      minDateTransform={getBeginOfDay}
+      view="month"
+    >
+      {getDay(date)}
+    </Tile>
+  );
+}
 
 Day.propTypes = {
   ...tileProps,
   currentMonthIndex: PropTypes.number.isRequired,
 };
-
-export default Day;

--- a/src/MonthView/Days.jsx
+++ b/src/MonthView/Days.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import TileGroup from '../TileGroup';
@@ -12,94 +12,68 @@ import {
 } from '../shared/dates';
 import { isCalendarType, tileGroupProps } from '../shared/propTypes';
 
-export default class Days extends PureComponent {
-  get offset() {
-    const { showFixedNumberOfWeeks, showNeighboringMonth } = this.props;
+export default function Days(props) {
+  const {
+    activeStartDate,
+    calendarType,
+  } = props;
+  const {
+    showFixedNumberOfWeeks,
+    showNeighboringMonth,
+    ...otherProps
+  } = props;
 
-    if (showFixedNumberOfWeeks || showNeighboringMonth) {
-      return 0;
-    }
+  const year = getYear(activeStartDate);
+  const monthIndex = getMonthIndex(activeStartDate);
 
-    const { activeStartDate, calendarType } = this.props;
+  const hasFixedNumberOfWeeks = showFixedNumberOfWeeks || showNeighboringMonth;
+  const dayOfWeek = getDayOfWeek(activeStartDate, calendarType);
 
-    return getDayOfWeek(activeStartDate, calendarType);
-  }
+  const offset = hasFixedNumberOfWeeks ? 0 : dayOfWeek;
 
   /**
    * Defines on which day of the month the grid shall start. If we simply show current
    * month, we obviously start on day one, but if showNeighboringMonth is set to
    * true, we need to find the beginning of the week the first day of the month is in.
    */
-  get start() {
-    const { showFixedNumberOfWeeks, showNeighboringMonth } = this.props;
-
-    if (showFixedNumberOfWeeks || showNeighboringMonth) {
-      const { activeStartDate, calendarType } = this.props;
-      return -getDayOfWeek(activeStartDate, calendarType) + 1;
-    }
-
-    return 1;
-  }
+  const start = (hasFixedNumberOfWeeks ? -dayOfWeek : 0) + 1;
 
   /**
    * Defines on which day of the month the grid shall end. If we simply show current
    * month, we need to stop on the last day of the month, but if showNeighboringMonth
    * is set to true, we need to find the end of the week the last day of the month is in.
    */
-  get end() {
-    const { activeStartDate, showFixedNumberOfWeeks, showNeighboringMonth } = this.props;
-    const daysInMonth = getDaysInMonth(activeStartDate);
-
+  const end = (() => {
     if (showFixedNumberOfWeeks) {
       // Always show 6 weeks
-      return this.start + (6 * 7) - 1;
+      return start + (6 * 7) - 1;
     }
 
+    const daysInMonth = getDaysInMonth(activeStartDate);
+
     if (showNeighboringMonth) {
-      const { year, monthIndex } = this;
-      const { calendarType } = this.props;
       const activeEndDate = new Date(year, monthIndex, daysInMonth);
       return daysInMonth + (7 - getDayOfWeek(activeEndDate, calendarType) - 1);
     }
 
     return daysInMonth;
-  }
+  })();
 
-  get year() {
-    const { activeStartDate } = this.props;
-    return getYear(activeStartDate);
-  }
-
-  get monthIndex() {
-    const { activeStartDate } = this.props;
-    return getMonthIndex(activeStartDate);
-  }
-
-  render() {
-    const { monthIndex } = this;
-
-    const {
-      showFixedNumberOfWeeks,
-      showNeighboringMonth,
-      ...otherProps
-    } = this.props;
-
-    return (
-      <TileGroup
-        {...otherProps}
-        className="react-calendar__month-view__days"
-        count={7}
-        dateTransform={day => new Date(this.year, monthIndex, day)}
-        dateType="day"
-        end={this.end}
-        offset={this.offset}
-        start={this.start}
-        tile={Day}
-        // Tile props
-        currentMonthIndex={monthIndex}
-      />
-    );
-  }
+  return (
+    <TileGroup
+      {...otherProps}
+      className="react-calendar__month-view__days"
+      count={7}
+      dateTransform={day => new Date(year, monthIndex, day)}
+      dateType="day"
+      end={end}
+      offset={offset}
+      start={start}
+      tile={Day}
+      // Tile props
+      currentMonthIndex={monthIndex}
+    />
+  );
 }
 
 Days.propTypes = {

--- a/src/MonthView/WeekNumber.jsx
+++ b/src/MonthView/WeekNumber.jsx
@@ -1,40 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const WeekNumber = ({
+export default function WeekNumber({
   date,
   onClickWeekNumber,
   weekNumber,
-}) => (
-  onClickWeekNumber
-    ? (
-      <button
-        className="react-calendar__tile"
-        onClick={() => onClickWeekNumber(weekNumber, date)}
-        style={{ flexGrow: 1 }}
-        type="button"
-      >
-        <span>
-          {weekNumber}
-        </span>
-      </button>
-    )
-    : (
-      <div
-        className="react-calendar__tile"
-        style={{ flexGrow: 1 }}
-      >
-        <span>
-          {weekNumber}
-        </span>
-      </div>
-    )
-);
+}) {
+  return (
+    onClickWeekNumber
+      ? (
+        <button
+          className="react-calendar__tile"
+          onClick={() => onClickWeekNumber(weekNumber, date)}
+          style={{ flexGrow: 1 }}
+          type="button"
+        >
+          <span>
+            {weekNumber}
+          </span>
+        </button>
+      )
+      : (
+        <div
+          className="react-calendar__tile"
+          style={{ flexGrow: 1 }}
+        >
+          <span>
+            {weekNumber}
+          </span>
+        </div>
+      )
+  );
+}
 
 WeekNumber.propTypes = {
   date: PropTypes.instanceOf(Date).isRequired,
   onClickWeekNumber: PropTypes.func,
   weekNumber: PropTypes.number.isRequired,
 };
-
-export default WeekNumber;

--- a/src/MonthView/WeekNumbers.jsx
+++ b/src/MonthView/WeekNumbers.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import WeekNumber from './WeekNumber';
@@ -15,88 +15,61 @@ import {
 } from '../shared/dates';
 import { isCalendarType } from '../shared/propTypes';
 
-export default class WeekNumbers extends PureComponent {
-  get startWeekday() {
-    const { activeStartDate, calendarType } = this.props;
-    return getDayOfWeek(activeStartDate, calendarType);
-  }
+export default function WeekNumbers(props) {
+  const {
+    activeStartDate,
+    calendarType,
+    onClickWeekNumber,
+    showFixedNumberOfWeeks,
+  } = props;
 
-  get numberOfDays() {
-    const { activeStartDate } = this.props;
-    return getDaysInMonth(activeStartDate);
-  }
-
-  get numberOfWeeks() {
-    const { showFixedNumberOfWeeks } = this.props;
-
+  const numberOfWeeks = (() => {
     if (showFixedNumberOfWeeks) {
       return 6;
     }
 
-    const days = this.numberOfDays - (7 - this.startWeekday);
+    const numberOfDays = getDaysInMonth(activeStartDate);
+    const startWeekday = getDayOfWeek(activeStartDate, calendarType);
+
+    const days = numberOfDays - (7 - startWeekday);
     return 1 + Math.ceil(days / 7);
-  }
+  })();
 
-  get year() {
-    const { activeStartDate } = this.props;
-    return getYear(activeStartDate);
-  }
+  const dates = (() => {
+    const year = getYear(activeStartDate);
+    const monthIndex = getMonthIndex(activeStartDate);
+    const day = getDay(activeStartDate);
 
-  get monthIndex() {
-    const { activeStartDate } = this.props;
-    return getMonthIndex(activeStartDate);
-  }
-
-  get day() {
-    const { activeStartDate } = this.props;
-    return getDay(activeStartDate);
-  }
-
-  get dates() {
-    const {
-      year, monthIndex, numberOfWeeks, day,
-    } = this;
-    const { calendarType } = this.props;
-
-    const dates = [];
+    const result = [];
     for (let index = 0; index < numberOfWeeks; index += 1) {
-      dates.push(
+      result.push(
         getBeginOfWeek(new Date(year, monthIndex, day + (index * 7)), calendarType),
       );
     }
-    return dates;
-  }
+    return result;
+  })();
 
-  get weekNumbers() {
-    const { dates } = this;
-    const { calendarType } = this.props;
-    return dates.map(date => getWeekNumber(date, calendarType));
-  }
+  const weekNumbers = dates.map(date => getWeekNumber(date, calendarType));
 
-  render() {
-    const { dates, numberOfWeeks, weekNumbers } = this;
-    const { onClickWeekNumber } = this.props;
-
-    return (
-      <Flex
-        className="react-calendar__month-view__weekNumbers"
-        count={numberOfWeeks}
-        direction="column"
-        style={{ flexBasis: 'calc(100% * (1 / 8)', flexShrink: 0 }}
-      >
-        {
-          weekNumbers.map((weekNumber, weekIndex) => (
-            <WeekNumber
-              date={dates[weekIndex]}
-              key={weekNumber}
-              onClickWeekNumber={onClickWeekNumber}
-              weekNumber={weekNumber}
-            />
-          ))
-        }
-      </Flex>
-    );
-  }
+  return (
+    <Flex
+      className="react-calendar__month-view__weekNumbers"
+      count={numberOfWeeks}
+      direction="column"
+      style={{ flexBasis: 'calc(100% * (1 / 8)', flexShrink: 0 }}
+    >
+      {
+        weekNumbers.map((weekNumber, weekIndex) => (
+          <WeekNumber
+            date={dates[weekIndex]}
+            key={weekNumber}
+            onClickWeekNumber={onClickWeekNumber}
+            weekNumber={weekNumber}
+          />
+        ))
+      }
+    </Flex>
+  );
 }
 
 WeekNumbers.propTypes = {

--- a/src/MonthView/Weekdays.jsx
+++ b/src/MonthView/Weekdays.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import Flex from '../Flex';
@@ -12,69 +12,47 @@ import {
 import { formatWeekday, formatShortWeekday as defaultFormatShortWeekday } from '../shared/dateFormatter';
 import { isCalendarType } from '../shared/propTypes';
 
-export default class Weekdays extends Component {
-  shouldComponentUpdate(nextProps) {
-    const { calendarType, locale } = this.props;
+export default function Weekdays(props) {
+  const {
+    calendarType,
+    formatShortWeekday,
+    locale,
+  } = props;
 
-    return (
-      nextProps.calendarType !== calendarType
-      || nextProps.locale !== locale
+  const anyDate = new Date();
+  const beginOfMonth = getBeginOfMonth(anyDate);
+  const year = getYear(beginOfMonth);
+  const monthIndex = getMonthIndex(beginOfMonth);
+
+  const weekdays = [];
+
+  for (let weekday = 1; weekday <= 7; weekday += 1) {
+    const weekdayDate = new Date(
+      year, monthIndex, weekday - getDayOfWeek(beginOfMonth, calendarType),
     );
-  }
 
-  get beginOfMonth() {
-    const { activeStartDate } = this.props;
+    const abbr = formatWeekday(locale, weekdayDate);
 
-    return getBeginOfMonth(activeStartDate);
-  }
-
-  get year() {
-    const { beginOfMonth } = this;
-
-    return getYear(beginOfMonth);
-  }
-
-  get monthIndex() {
-    const { beginOfMonth } = this;
-
-    return getMonthIndex(beginOfMonth);
-  }
-
-  render() {
-    const { calendarType, formatShortWeekday, locale } = this.props;
-    const { beginOfMonth, year, monthIndex } = this;
-
-    const weekdays = [];
-
-    for (let weekday = 1; weekday <= 7; weekday += 1) {
-      const weekdayDate = new Date(
-        year, monthIndex, weekday - getDayOfWeek(beginOfMonth, calendarType),
-      );
-
-      const abbr = formatWeekday(locale, weekdayDate);
-
-      weekdays.push(
-        <div
-          className="react-calendar__month-view__weekdays__weekday"
-          key={weekday}
-          style={{ flexGrow: 1 }}
-        >
-          <abbr title={abbr} aria-label={abbr}>
-            {formatShortWeekday(locale, weekdayDate).replace('.', '')}
-          </abbr>
-        </div>,
-      );
-    }
-
-    return (
-      <Flex
-        className="react-calendar__month-view__weekdays"
-        count={7}
+    weekdays.push(
+      <div
+        className="react-calendar__month-view__weekdays__weekday"
+        key={weekday}
       >
-        {weekdays}
-      </Flex>
+        <abbr title={abbr} aria-label={abbr}>
+          {formatShortWeekday(locale, weekdayDate).replace('.', '')}
+        </abbr>
+      </div>,
     );
   }
+
+  return (
+    <Flex
+      className="react-calendar__month-view__weekdays"
+      count={7}
+    >
+      {weekdays}
+    </Flex>
+  );
 }
 
 Weekdays.defaultProps = {
@@ -85,5 +63,4 @@ Weekdays.propTypes = {
   calendarType: isCalendarType.isRequired,
   formatShortWeekday: PropTypes.func,
   locale: PropTypes.string,
-  activeStartDate: PropTypes.instanceOf(Date).isRequired,
 };

--- a/src/MonthView/__tests__/Weekdays.jsx
+++ b/src/MonthView/__tests__/Weekdays.jsx
@@ -5,15 +5,10 @@ import Weekdays from '../Weekdays';
 
 /* eslint-disable comma-dangle */
 
-const weekdaysProps = {
-  activeStartDate: new Date(2018, 0, 1),
-};
-
 describe('Weekdays', () => {
   it('renders proper weekdays (ISO 8601)', () => {
     const component = mount(
       <Weekdays
-        {...weekdaysProps}
         calendarType="ISO 8601"
       />
     );
@@ -30,7 +25,6 @@ describe('Weekdays', () => {
   it('renders proper weekdays (US)', () => {
     const component = mount(
       <Weekdays
-        {...weekdaysProps}
         calendarType="US"
       />
     );

--- a/src/YearView/Month.jsx
+++ b/src/YearView/Month.jsx
@@ -15,26 +15,28 @@ import { tileProps } from '../shared/propTypes';
 
 const className = 'react-calendar__year-view__months__month';
 
-const Month = ({
+export default function Month({
   classes,
   date,
   formatMonth,
   locale,
   ...otherProps
-}) => (
-  <Tile
-    {...otherProps}
-    classes={[...classes, className]}
-    date={date}
-    formatAbbr={formatMonthYear}
-    locale={locale}
-    maxDateTransform={getEndOfMonth}
-    minDateTransform={getBeginOfMonth}
-    view="year"
-  >
-    {formatMonth(locale, date)}
-  </Tile>
-);
+}) {
+  return (
+    <Tile
+      {...otherProps}
+      classes={[].concat(classes, className)}
+      date={date}
+      formatAbbr={formatMonthYear}
+      locale={locale}
+      maxDateTransform={getEndOfMonth}
+      minDateTransform={getBeginOfMonth}
+      view="year"
+    >
+      {formatMonth(locale, date)}
+    </Tile>
+  );
+}
 
 Month.defaultProps = {
   formatMonth: defaultFormatMonth,
@@ -44,5 +46,3 @@ Month.propTypes = {
   ...tileProps,
   formatMonth: PropTypes.func,
 };
-
-export default Month;

--- a/src/YearView/Months.jsx
+++ b/src/YearView/Months.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import TileGroup from '../TileGroup';
@@ -7,29 +7,23 @@ import Month from './Month';
 import { getYear } from '../shared/dates';
 import { tileGroupProps } from '../shared/propTypes';
 
-export default class Months extends PureComponent {
-  start = 0
+export default function Months(props) {
+  const { activeStartDate } = props;
+  const start = 0;
+  const end = 11;
+  const year = getYear(activeStartDate);
 
-  end = 11
-
-  get year() {
-    const { activeStartDate } = this.props;
-    return getYear(activeStartDate);
-  }
-
-  render() {
-    return (
-      <TileGroup
-        {...this.props}
-        className="react-calendar__year-view__months"
-        dateTransform={monthIndex => new Date(this.year, monthIndex, 1)}
-        dateType="month"
-        end={this.end}
-        start={this.start}
-        tile={Month}
-      />
-    );
-  }
+  return (
+    <TileGroup
+      {...props}
+      className="react-calendar__year-view__months"
+      dateTransform={monthIndex => new Date(year, monthIndex, 1)}
+      dateType="month"
+      end={end}
+      start={start}
+      tile={Month}
+    />
+  );
 }
 
 Months.propTypes = {


### PR DESCRIPTION
This shaves off ~20 KB from the code compiled by Babel by various optimizations (mostly getting rid of needless arrow functions and class components).