### PR TITLE
Fix color contrast ratio for month view accessibility

### DIFF
--- a/src/Calendar.less
+++ b/src/Calendar.less
@@ -71,11 +71,11 @@
     &__days {
       &__day {
         &--weekend {
-          color: red;
+          color: rgb(209, 0, 0);
         }
 
         &--neighboringMonth {
-          color: rgb(150, 150, 150);
+          color: rgb(117, 117, 117)
         }
       }
     }


### PR DESCRIPTION
Using macOS Safari. 
Hover over any of the weekend dates with the mouse, the observed behaviour for the hovered weekend date is Red text (#FF0000) against a grey background (#E6E6E6), which gives contrast ratio of 3.2:1, which fails color contrast requirements for small text. Font size is 15.2px (equivalent of 11.4pt), normal font weight.

Changing it to a darker shade of red (#D10000/rgb(209,0,0)) which gives a contrast ratio of 4.53:1.

Also, color contrast ratio of the previous month dates. Grey text (#969696) against a white background (#FFFFFF) results in a contrast ratio of 2.95:1 which fails color contrast requirements.

Using a darker shade of grey for text, (#757575/rgb(117, 117, 117)) which gives color contrast ratio of 4.60:1.

Above colors pass WCAG2.0 AA standard. Much darker color shades can be used to pass WCAG AAA standard e.g. #595959 & #990000.