### PR TITLE
Add aria-label props for navigation buttons

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -462,10 +462,15 @@ export default class Calendar extends Component {
       maxDetail,
       minDate,
       minDetail,
-      next2Label,
-      nextLabel,
+      navigationAriaLabel,
       navigationLabel,
+      next2AriaLabel,
+      next2Label,
+      nextAriaLabel,
+      nextLabel,
+      prev2AriaLabel,
       prev2Label,
+      prevAriaLabel,
       prevLabel,
     } = this.props;
     const { activeStartDate, view } = this.state;
@@ -478,10 +483,15 @@ export default class Calendar extends Component {
         locale={locale}
         maxDate={maxDate}
         minDate={minDate}
-        next2Label={next2Label}
-        nextLabel={nextLabel}
+        navigationAriaLabel={navigationAriaLabel}
         navigationLabel={navigationLabel}
+        next2AriaLabel={next2AriaLabel}
+        next2Label={next2Label}
+        nextAriaLabel={nextAriaLabel}
+        nextLabel={nextLabel}
+        prev2AriaLabel={prev2AriaLabel}
         prev2Label={prev2Label}
+        prevAriaLabel={prevAriaLabel}
         prevLabel={prevLabel}
         setActiveStartDate={this.setActiveStartDate}
         view={view}
@@ -534,8 +544,11 @@ Calendar.propTypes = {
   maxDetail: PropTypes.oneOf(allViews),
   minDate: isMinDate,
   minDetail: PropTypes.oneOf(allViews),
+  navigationAriaLabel: PropTypes.string,
   navigationLabel: PropTypes.func,
+  next2AriaLabel: PropTypes.string,
   next2Label: PropTypes.node,
+  nextAriaLabel: PropTypes.string,
   nextLabel: PropTypes.node,
   onActiveDateChange: PropTypes.func,
   onChange: PropTypes.func,
@@ -546,7 +559,9 @@ Calendar.propTypes = {
   onClickYear: PropTypes.func,
   onDrillDown: PropTypes.func,
   onDrillUp: PropTypes.func,
+  prev2AriaLabel: PropTypes.string,
   prev2Label: PropTypes.node,
+  prevAriaLabel: PropTypes.string,
   prevLabel: PropTypes.node,
   renderChildren: PropTypes.func, // For backwards compatibility
   returnValue: PropTypes.oneOf(['start', 'end', 'range']),

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -24,10 +24,15 @@ export default function Navigation({
   locale,
   maxDate,
   minDate,
+  navigationAriaLabel,
   navigationLabel,
+  next2AriaLabel,
   next2Label,
+  nextAriaLabel,
   nextLabel,
+  prev2AriaLabel,
   prev2Label,
+  prevAriaLabel,
   prevLabel,
   setActiveStartDate,
   view,
@@ -107,6 +112,7 @@ export default function Navigation({
           disabled={prev2ButtonDisabled}
           onClick={onClickPrevious2}
           type="button"
+          aria-label={prev2AriaLabel}
         >
           {prev2Label}
         </button>
@@ -116,6 +122,7 @@ export default function Navigation({
         disabled={prevButtonDisabled}
         onClick={onClickPrevious}
         type="button"
+        aria-label={prevAriaLabel}
       >
         {prevLabel}
       </button>
@@ -125,6 +132,7 @@ export default function Navigation({
         disabled={!drillUpAvailable}
         style={{ flexGrow: 1 }}
         type="button"
+        aria-label={navigationAriaLabel}
       >
         {navigationLabel
           ? navigationLabel({ date, view, label })
@@ -136,6 +144,7 @@ export default function Navigation({
         disabled={nextButtonDisabled}
         onClick={onClickNext}
         type="button"
+        aria-label={nextAriaLabel}
       >
         {nextLabel}
       </button>
@@ -145,6 +154,7 @@ export default function Navigation({
           disabled={next2ButtonDisabled}
           onClick={onClickNext2}
           type="button"
+          aria-label={next2AriaLabel}
         >
           {next2Label}
         </button>
@@ -155,9 +165,14 @@ export default function Navigation({
 
 Navigation.defaultProps = {
   formatMonthYear: defaultFormatMonthYear,
+  navigationAriaLabel: '',
+  next2AriaLabel: '',
   next2Label: '»',
+  nextAriaLabel: '',
   nextLabel: '›',
+  prev2AriaLabel: '',
   prev2Label: '«',
+  prevAriaLabel: '',
   prevLabel: '‹',
 };
 
@@ -168,10 +183,15 @@ Navigation.propTypes = {
   locale: PropTypes.string,
   maxDate: PropTypes.instanceOf(Date),
   minDate: PropTypes.instanceOf(Date),
+  next2AriaLabel: PropTypes.string,
   next2Label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  nextAriaLabel: PropTypes.string,
   nextLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  navigationAriaLabel: PropTypes.string,
   navigationLabel: PropTypes.func,
+  prev2AriaLabel: PropTypes.string,
   prev2Label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  prevAriaLabel: PropTypes.string,
   prevLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   setActiveStartDate: PropTypes.func.isRequired,
   view: isView.isRequired,

--- a/src/Calendar/__tests__/Navigation.jsx
+++ b/src/Calendar/__tests__/Navigation.jsx
@@ -139,6 +139,31 @@ describe('Navigation', () => {
     expect(next2.props.children).toBe('next2Label');
   });
 
+  it('displays proper user-defined ARIA labels on prev2, prev, navigation, next and next2 buttons', () => {
+    const component = shallow(
+      <Navigation
+        activeStartDate={new Date(2017, 0, 1)}
+        drillUp={jest.fn()}
+        navigationAriaLabel="navigationAriaLabel"
+        next2AriaLabel="next2AriaLabel"
+        nextAriaLabel="nextAriaLabel"
+        prev2AriaLabel="prev2AriaLabel"
+        prevAriaLabel="prevAriaLabel"
+        setActiveStartDate={jest.fn()}
+        view="month"
+        views={allViews}
+      />
+    );
+
+    const [prev2, prev, navigation, next, next2] = component.children();
+
+    expect(prev2.props['aria-label']).toBe('prev2AriaLabel');
+    expect(prev.props['aria-label']).toBe('prevAriaLabel');
+    expect(navigation.props['aria-label']).toBe('navigationAriaLabel');
+    expect(next.props['aria-label']).toBe('nextAriaLabel');
+    expect(next2.props['aria-label']).toBe('next2AriaLabel');
+  });
+
   it('calls drillUp function on drill up button click', () => {
     const drillUpFn = jest.fn();
     const component = shallow(


### PR DESCRIPTION
Using macOS VoiceOver with Safari or IE+JAWS, the previous/next buttons on the calendar picker are announced as 'left/right-pointing double arrow' and 'single left/right-pointing angle quotation mark'.

Ability to provide aria labels for navigation buttons. 
Currently, I haven't added default props but we can also add default aria-labels like 'Previous year/Next year' etc. 