### PR TITLE
Fix performance when using selectRange

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -503,6 +503,7 @@ export default class Calendar extends Component {
           className,
         )}
         onMouseLeave={selectRange ? onMouseLeave : null}
+        onBlur={selectRange ? onMouseLeave : null}
       >
         {this.renderNavigation()}
         {this.renderContent()}

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -344,10 +344,13 @@ export default class Calendar extends Component {
   }
 
   onMouseOver = (value) => {
-    this.setState({ hover: value });
+    const { hover } = this.state;
+    if ((hover && hover.getTime()) !== value.getTime()) {
+      this.setState({ hover: value });
+    }
   }
 
-  onMouseOut = () => {
+  onMouseLeave = () => {
     this.setState({ hover: null });
   }
 
@@ -489,7 +492,7 @@ export default class Calendar extends Component {
   render() {
     const { className, selectRange } = this.props;
     const { value } = this.state;
-    const { onMouseOut } = this;
+    const { onMouseLeave } = this;
     const valueArray = [].concat(value);
 
     return (
@@ -499,8 +502,7 @@ export default class Calendar extends Component {
           selectRange && valueArray.length === 1 && 'react-calendar--selectRange',
           className,
         )}
-        onMouseOut={selectRange ? onMouseOut : null}
-        onBlur={selectRange ? onMouseOut : null}
+        onMouseLeave={selectRange ? onMouseLeave : null}
       >
         {this.renderNavigation()}
         {this.renderContent()}

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -348,10 +348,13 @@ export default class Calendar extends Component {
   }
 
   onMouseOver = (value) => {
-    const { hover } = this.state;
-    if ((hover && hover.getTime()) !== value.getTime()) {
-      this.setState({ hover: value });
-    }
+    this.setState((prevState) => {
+      if (prevState.hover && (prevState.hover.getTime() === value.getTime())) {
+        return null;
+      }
+
+      return { hover: value };
+    });
   }
 
   onMouseLeave = () => {
@@ -373,7 +376,7 @@ export default class Calendar extends Component {
     const {
       activeStartDate, hover, value, view,
     } = this.state;
-    const { onMouseOver, valueType } = this;
+    const { onMouseLeave, onMouseOver, valueType } = this;
 
     const commonProps = {
       activeStartDate,
@@ -381,6 +384,7 @@ export default class Calendar extends Component {
       locale,
       maxDate,
       minDate,
+      onMouseLeave,
       onMouseOver: selectRange ? onMouseOver : null,
       tileClassName,
       tileContent: tileContent || renderChildren, // For backwards compatibility
@@ -516,7 +520,6 @@ export default class Calendar extends Component {
           selectRange && valueArray.length === 1 && 'react-calendar--selectRange',
           className,
         )}
-        onMouseLeave={selectRange ? onMouseLeave : null}
         onBlur={selectRange ? onMouseLeave : null}
       >
         {this.renderNavigation()}

--- a/src/CenturyView.jsx
+++ b/src/CenturyView.jsx
@@ -13,8 +13,10 @@ export default class CenturyView extends PureComponent {
   }
 
   render() {
+    const { onMouseLeave } = this.props;
+
     return (
-      <div className="react-calendar__century-view">
+      <div className="react-calendar__century-view" onMouseLeave={onMouseLeave}>
         {this.renderDecades()}
       </div>
     );

--- a/src/CenturyView/Decade.jsx
+++ b/src/CenturyView/Decade.jsx
@@ -9,7 +9,7 @@ import TileHOC from '../shared/TileHOC';
 
 const className = 'react-calendar__century-view__decades__decade';
 
-export default function Decade({ classes, point, ...otherProps }) {
+function Decade({ classes, point, ...otherProps }) {
   return (
     <Tile
       {...otherProps}
@@ -27,3 +27,5 @@ Decade.propTypes = {
   ...tileProps,
   point: PropTypes.number.isRequired,
 };
+
+export default TileHOC(Decade);

--- a/src/CenturyView/Decade.jsx
+++ b/src/CenturyView/Decade.jsx
@@ -5,6 +5,7 @@ import Tile from '../Tile';
 
 import { getBeginOfDecade, getDecadeLabel, getEndOfDecade } from '../shared/dates';
 import { tileProps } from '../shared/propTypes';
+import TileHOC from '../shared/TileHOC';
 
 const className = 'react-calendar__century-view__decades__decade';
 
@@ -25,4 +26,4 @@ Decade.propTypes = {
   point: PropTypes.number.isRequired,
 };
 
-export default Decade;
+export default TileHOC(Decade);

--- a/src/DecadeView.jsx
+++ b/src/DecadeView.jsx
@@ -13,8 +13,10 @@ export default class DecadeView extends PureComponent {
   }
 
   render() {
+    const { onMouseLeave } = this.props;
+
     return (
-      <div className="react-calendar__decade-view">
+      <div className="react-calendar__decade-view" onMouseLeave={onMouseLeave}>
         {this.renderYears()}
       </div>
     );

--- a/src/DecadeView/Year.jsx
+++ b/src/DecadeView/Year.jsx
@@ -9,7 +9,7 @@ import TileHOC from '../shared/TileHOC';
 
 const className = 'react-calendar__decade-view__years__year';
 
-export default function Year({ classes, point, ...otherProps }) {
+function Year({ classes, point, ...otherProps }) {
   return (
     <Tile
       {...otherProps}
@@ -27,3 +27,5 @@ Year.propTypes = {
   ...tileProps,
   point: PropTypes.number.isRequired,
 };
+
+export default TileHOC(Year);

--- a/src/DecadeView/Year.jsx
+++ b/src/DecadeView/Year.jsx
@@ -5,6 +5,7 @@ import Tile from '../Tile';
 
 import { getBeginOfYear, getEndOfYear } from '../shared/dates';
 import { tileProps } from '../shared/propTypes';
+import TileHOC from '../shared/TileHOC';
 
 const className = 'react-calendar__decade-view__years__year';
 
@@ -25,4 +26,4 @@ Year.propTypes = {
   point: PropTypes.number.isRequired,
 };
 
-export default Year;
+export default TileHOC(Year);

--- a/src/MonthView.jsx
+++ b/src/MonthView.jsx
@@ -122,7 +122,7 @@ export default class MonthView extends PureComponent {
   }
 
   render() {
-    const { showWeekNumbers } = this.props;
+    const { onMouseLeave, showWeekNumbers } = this.props;
 
     const className = 'react-calendar__month-view';
 
@@ -132,6 +132,7 @@ export default class MonthView extends PureComponent {
           className,
           showWeekNumbers ? `${className}--weekNumbers` : '',
         ].join(' ')}
+        onMouseLeave={onMouseLeave}
       >
         <div
           style={{

--- a/src/MonthView/Day.jsx
+++ b/src/MonthView/Day.jsx
@@ -15,7 +15,7 @@ import TileHOC from '../shared/TileHOC';
 
 const className = 'react-calendar__month-view__days__day';
 
-export default function Day({
+function Day({
   calendarType,
   classes,
   currentMonthIndex,
@@ -46,3 +46,5 @@ Day.propTypes = {
   ...tileProps,
   currentMonthIndex: PropTypes.number.isRequired,
 };
+
+export default TileHOC(Day);

--- a/src/MonthView/Day.jsx
+++ b/src/MonthView/Day.jsx
@@ -11,6 +11,7 @@ import {
 } from '../shared/dates';
 import { formatLongDate } from '../shared/dateFormatter';
 import { tileProps } from '../shared/propTypes';
+import TileHOC from '../shared/TileHOC';
 
 const className = 'react-calendar__month-view__days__day';
 
@@ -44,4 +45,4 @@ Day.propTypes = {
   currentMonthIndex: PropTypes.number.isRequired,
 };
 
-export default Day;
+export default TileHOC(Day);

--- a/src/YearView.jsx
+++ b/src/YearView.jsx
@@ -13,8 +13,10 @@ export default class YearView extends PureComponent {
   }
 
   render() {
+    const { onMouseLeave } = this.props;
+
     return (
-      <div className="react-calendar__year-view">
+      <div className="react-calendar__year-view" onMouseLeave={onMouseLeave}>
         {this.renderMonths()}
       </div>
     );

--- a/src/YearView/Month.jsx
+++ b/src/YearView/Month.jsx
@@ -16,7 +16,7 @@ import TileHOC from '../shared/TileHOC';
 
 const className = 'react-calendar__year-view__months__month';
 
-export default function Month({
+function Month({
   classes,
   date,
   formatMonth,
@@ -47,3 +47,5 @@ Month.propTypes = {
   ...tileProps,
   formatMonth: PropTypes.func,
 };
+
+export default TileHOC(Month);

--- a/src/YearView/Month.jsx
+++ b/src/YearView/Month.jsx
@@ -12,6 +12,7 @@ import {
   formatMonthYear,
 } from '../shared/dateFormatter';
 import { tileProps } from '../shared/propTypes';
+import TileHOC from '../shared/TileHOC';
 
 const className = 'react-calendar__year-view__months__month';
 
@@ -45,4 +46,4 @@ Month.propTypes = {
   formatMonth: PropTypes.func,
 };
 
-export default Month;
+export default TileHOC(Month);

--- a/src/shared/TileHOC.jsx
+++ b/src/shared/TileHOC.jsx
@@ -3,10 +3,7 @@ import React, { Component } from 'react';
 export default ChildComponent => class extends Component {
   shouldComponentUpdate(nextProps) {
     const { classes } = this.props;
-    if (JSON.stringify(classes) !== JSON.stringify(nextProps.classes)) {
-      return true;
-    }
-    return false;
+    return JSON.stringify(classes) !== JSON.stringify(nextProps.classes);
   }
 
   render() {

--- a/src/shared/TileHOC.jsx
+++ b/src/shared/TileHOC.jsx
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+
+export default ChildComponent => class extends Component {
+  shouldComponentUpdate(nextProps) {
+    const { classes } = this.props;
+    if (JSON.stringify(classes) !== JSON.stringify(nextProps.classes)) {
+      return true;
+    }
+    return false;
+  }
+
+  render() {
+    return <ChildComponent {...this.props} />;
+  }
+};


### PR DESCRIPTION
## Description
Change `onMouseOut` with `onMouseLeave` because `onMouseOut` was being called even when the cursor was still within the dimensions of the calendar.  Also added `TileHOC` to prevent unnecessary re-renders for tiles that should not update when moving the mouse to highlight tiles.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `selectRange` prop was causing many unneccessary re-renders, causing hovering and selecting multiple dates to feel sluggish.  Fixes #178 

## How Has This Been Tested? (Manual Test Steps)
Add the `selectRange` prop in `Sample.jsx` and see that there is much less re-rendering occurring in the React devtools.

# before
![May-02-2019 06-04-47](https://user-images.githubusercontent.com/24510642/57077180-38802480-6ca0-11e9-8082-65b2fd84d1d4.gif)

# after
![May-02-2019 06-04-41](https://user-images.githubusercontent.com/24510642/57077182-38802480-6ca0-11e9-885c-27925fd92514.gif)
