### PR TITLE
Fix year not being properly localized in th-TH locale, add formatYear custom function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Displays a complete, interactive calendar.
 |formatMonth|Function called to override default formatting of month names. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'MMM')`|
 |formatMonthYear|Function called to override default formatting of month and year in the top navigation section. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'MMMM YYYY')`|
 |formatShortWeekday|Function called to override default formatting of weekday names. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'dd')`|
+|formatYear|Function called to override default formatting of year in the top navigation section. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'YYYY')`|
 |locale|Locale that should be used by the calendar. Can be any [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag).|User's browser settings|`"hu-HU"`|
 |maxDate|Maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although React-Calendar will ensure that no later date is selected.|n/a|Date: `new Date()`|
 |maxDetail|The most detailed view that the user shall see. View defined here also becomes the one on which clicking an item will select a date and pass it to onChange. Can be `"month"`, `"year"`, `"decade"` or `"century"`.|`"month"`|`"year"`|

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare module "react-calendar" {
     formatMonth?: FormatterCallback;
     formatMonthYear?: FormatterCallback;
     formatShortWeekday?: FormatterCallback;
+    formatYear?: FormatterCallback;
     locale?: string;
     maxDate?: Date;
     maxDetail?: Detail;

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -401,20 +401,22 @@ export default class Calendar extends Component {
 
     switch (view) {
       case 'century': {
-        const { onClickDecade } = this.props;
+        const { formatYear, onClickDecade } = this.props;
 
         return (
           <CenturyView
+            formatYear={formatYear}
             onClick={mergeFunctions(clickAction, onClickDecade)}
             {...commonProps}
           />
         );
       }
       case 'decade': {
-        const { onClickYear } = this.props;
+        const { formatYear, onClickYear } = this.props;
 
         return (
           <DecadeView
+            formatYear={formatYear}
             onClick={mergeFunctions(clickAction, onClickYear)}
             {...commonProps}
           />
@@ -470,6 +472,7 @@ export default class Calendar extends Component {
 
     const {
       formatMonthYear,
+      formatYear,
       locale,
       maxDate,
       maxDetail,
@@ -493,6 +496,7 @@ export default class Calendar extends Component {
         activeStartDate={activeStartDate}
         drillUp={this.drillUp}
         formatMonthYear={formatMonthYear}
+        formatYear={formatYear}
         locale={locale}
         maxDate={maxDate}
         minDate={minDate}
@@ -556,6 +560,7 @@ Calendar.propTypes = {
   formatMonth: PropTypes.func,
   formatMonthYear: PropTypes.func,
   formatShortWeekday: PropTypes.func,
+  formatYear: PropTypes.func,
   locale: PropTypes.string,
   maxDate: isMaxDate,
   maxDetail: PropTypes.oneOf(allViews),

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -10,9 +10,11 @@ import {
   getBeginPrevious2,
   getEndPrevious,
   getEndPrevious2,
-  getYear,
 } from '../shared/dates';
-import { formatMonthYear as defaultFormatMonthYear } from '../shared/dateFormatter';
+import {
+  formatMonthYear as defaultFormatMonthYear,
+  formatYear as defaultFormatYear,
+} from '../shared/dateFormatter';
 import { isView, isViews } from '../shared/propTypes';
 
 const className = 'react-calendar__navigation';
@@ -21,6 +23,7 @@ export default function Navigation({
   activeStartDate: date,
   drillUp,
   formatMonthYear,
+  formatYear,
   locale,
   maxDate,
   minDate,
@@ -89,11 +92,11 @@ export default function Navigation({
   const label = (() => {
     switch (view) {
       case 'century':
-        return getCenturyLabel(date);
+        return getCenturyLabel(locale, formatYear, date);
       case 'decade':
-        return getDecadeLabel(date);
+        return getDecadeLabel(locale, formatYear, date);
       case 'year':
-        return getYear(date);
+        return formatYear(locale, date);
       case 'month':
         return formatMonthYear(locale, date);
       default:
@@ -164,6 +167,7 @@ export default function Navigation({
 
 Navigation.defaultProps = {
   formatMonthYear: defaultFormatMonthYear,
+  formatYear: defaultFormatYear,
   navigationAriaLabel: '',
   next2AriaLabel: '',
   next2Label: '»',
@@ -179,6 +183,7 @@ Navigation.propTypes = {
   activeStartDate: PropTypes.instanceOf(Date).isRequired,
   drillUp: PropTypes.func.isRequired,
   formatMonthYear: PropTypes.func,
+  formatYear: PropTypes.func,
   locale: PropTypes.string,
   maxDate: PropTypes.instanceOf(Date),
   minDate: PropTypes.instanceOf(Date),

--- a/src/CenturyView/Decade.jsx
+++ b/src/CenturyView/Decade.jsx
@@ -4,25 +4,38 @@ import PropTypes from 'prop-types';
 import Tile from '../Tile';
 
 import { getBeginOfDecade, getDecadeLabel, getEndOfDecade } from '../shared/dates';
+import { formatYear as defaultFormatYear } from '../shared/dateFormatter';
 import { tileProps } from '../shared/propTypes';
 
 const className = 'react-calendar__century-view__decades__decade';
 
-export default function Decade({ classes, point, ...otherProps }) {
+export default function Decade({
+  classes,
+  date,
+  formatYear,
+  locale,
+  ...otherProps
+}) {
   return (
     <Tile
       {...otherProps}
       classes={[].concat(classes, className)}
+      date={date}
+      locale={locale}
       maxDateTransform={getEndOfDecade}
       minDateTransform={getBeginOfDecade}
       view="century"
     >
-      {getDecadeLabel(point)}
+      {getDecadeLabel(locale, formatYear, date)}
     </Tile>
   );
 }
 
+Decade.defaultProps = {
+  formatYear: defaultFormatYear,
+};
+
 Decade.propTypes = {
   ...tileProps,
-  point: PropTypes.number.isRequired,
+  formatYear: PropTypes.func,
 };

--- a/src/DecadeView/Year.jsx
+++ b/src/DecadeView/Year.jsx
@@ -4,25 +4,38 @@ import PropTypes from 'prop-types';
 import Tile from '../Tile';
 
 import { getBeginOfYear, getEndOfYear } from '../shared/dates';
+import { formatYear as defaultFormatYear } from '../shared/dateFormatter';
 import { tileProps } from '../shared/propTypes';
 
 const className = 'react-calendar__decade-view__years__year';
 
-export default function Year({ classes, point, ...otherProps }) {
+export default function Year({
+  classes,
+  date,
+  formatYear,
+  locale,
+  ...otherProps
+}) {
   return (
     <Tile
       {...otherProps}
       classes={[].concat(classes, className)}
+      date={date}
+      locale={locale}
       maxDateTransform={getEndOfYear}
       minDateTransform={getBeginOfYear}
       view="decade"
     >
-      {point}
+      {formatYear(locale, date)}
     </Tile>
   );
 }
 
+Year.defaultProps = {
+  formatYear: defaultFormatYear,
+};
+
 Year.propTypes = {
   ...tileProps,
-  point: PropTypes.number.isRequired,
+  formatYear: PropTypes.func,
 };

--- a/src/__tests__/Calendar.jsx
+++ b/src/__tests__/Calendar.jsx
@@ -281,185 +281,187 @@ describe('Calendar', () => {
     expect(onDrillDown).not.toHaveBeenCalled();
   });
 
-  it('calls onChange function returning the beginning of selected period by default', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        onChange={onChange}
-        view="month"
-      />
-    );
+  describe('calls onChange properly', () => {
+    it('calls onChange function returning the beginning of selected period by default', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          onChange={onChange}
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2017, 0, 1));
+      component.instance().onChange(new Date(2017, 0, 1));
 
-    expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1));
-  });
+      expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1));
+    });
 
-  it('calls onChange function returning the beginning of the selected period when returnValue is set to "start"', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        onChange={onChange}
-        returnValue="start"
-        view="month"
-      />
-    );
+    it('calls onChange function returning the beginning of the selected period when returnValue is set to "start"', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          onChange={onChange}
+          returnValue="start"
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2017, 0, 1));
+      component.instance().onChange(new Date(2017, 0, 1));
 
-    expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1));
-  });
+      expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1));
+    });
 
-  it('calls onChange function returning the beginning of the selected period when returnValue is set to "start"', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        onChange={onChange}
-        returnValue="start"
-        view="month"
-      />
-    );
+    it('calls onChange function returning the beginning of the selected period when returnValue is set to "start"', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          onChange={onChange}
+          returnValue="start"
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2017, 0, 1));
+      component.instance().onChange(new Date(2017, 0, 1));
 
-    expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1));
-  });
+      expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1));
+    });
 
-  it('calls onChange function returning the end of the selected period when returnValue is set to "end"', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        onChange={onChange}
-        returnValue="end"
-        view="month"
-      />
-    );
+    it('calls onChange function returning the end of the selected period when returnValue is set to "end"', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          onChange={onChange}
+          returnValue="end"
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2017, 0, 1));
+      component.instance().onChange(new Date(2017, 0, 1));
 
-    expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1, 23, 59, 59, 999));
-  });
+      expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1, 23, 59, 59, 999));
+    });
 
-  it('calls onChange function returning the beginning of selected period when returnValue is set to "range"', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        onChange={onChange}
-        returnValue="range"
-        view="month"
-      />
-    );
+    it('calls onChange function returning the beginning of selected period when returnValue is set to "range"', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          onChange={onChange}
+          returnValue="range"
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2017, 0, 1));
+      component.instance().onChange(new Date(2017, 0, 1));
 
-    expect(onChange).toHaveBeenCalledWith([
-      new Date(2017, 0, 1),
-      new Date(2017, 0, 1, 23, 59, 59, 999),
-    ]);
-  });
+      expect(onChange).toHaveBeenCalledWith([
+        new Date(2017, 0, 1),
+        new Date(2017, 0, 1, 23, 59, 59, 999),
+      ]);
+    });
 
-  it('calls onChange function returning the beginning of selected period, but no earlier than minDate', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        minDate={new Date(2017, 0, 1, 12)}
-        onChange={onChange}
-        returnValue="start"
-        view="month"
-      />
-    );
+    it('calls onChange function returning the beginning of selected period, but no earlier than minDate', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          minDate={new Date(2017, 0, 1, 12)}
+          onChange={onChange}
+          returnValue="start"
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2017, 0, 1));
+      component.instance().onChange(new Date(2017, 0, 1));
 
-    expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1, 12));
-  });
+      expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1, 12));
+    });
 
-  it('calls onChange function returning the beginning of selected period, but no later than maxDate', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        maxDate={new Date(2017, 0, 1, 12)}
-        onChange={onChange}
-        returnValue="start"
-        view="month"
-      />
-    );
+    it('calls onChange function returning the beginning of selected period, but no later than maxDate', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          maxDate={new Date(2017, 0, 1, 12)}
+          onChange={onChange}
+          returnValue="start"
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2017, 0, 2));
+      component.instance().onChange(new Date(2017, 0, 2));
 
-    expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1, 12));
-  });
+      expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1, 12));
+    });
 
-  it('calls onChange function returning the end of selected period, but no earlier than minDate', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        minDate={new Date(2017, 0, 2, 12)}
-        onChange={onChange}
-        returnValue="end"
-        view="month"
-      />
-    );
+    it('calls onChange function returning the end of selected period, but no earlier than minDate', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          minDate={new Date(2017, 0, 2, 12)}
+          onChange={onChange}
+          returnValue="end"
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2017, 0, 1));
+      component.instance().onChange(new Date(2017, 0, 1));
 
-    expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 2, 12));
-  });
+      expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 2, 12));
+    });
 
-  it('calls onChange function returning the end of selected period, but no later than maxDate', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        maxDate={new Date(2017, 0, 1, 12)}
-        onChange={onChange}
-        returnValue="end"
-        view="month"
-      />
-    );
+    it('calls onChange function returning the end of selected period, but no later than maxDate', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          maxDate={new Date(2017, 0, 1, 12)}
+          onChange={onChange}
+          returnValue="end"
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2017, 0, 2));
+      component.instance().onChange(new Date(2017, 0, 2));
 
-    expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1, 12));
-  });
+      expect(onChange).toHaveBeenCalledWith(new Date(2017, 0, 1, 12));
+    });
 
-  it('calls onChange function returning a range when selected two pieces of a range', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        onChange={onChange}
-        selectRange
-        view="month"
-      />
-    );
+    it('calls onChange function returning a range when selected two pieces of a range', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          onChange={onChange}
+          selectRange
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2018, 0, 1));
-    component.instance().onChange(new Date(2018, 6, 1));
+      component.instance().onChange(new Date(2018, 0, 1));
+      component.instance().onChange(new Date(2018, 6, 1));
 
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith([
-      new Date(2018, 0, 1),
-      new Date(2018, 6, 1, 23, 59, 59, 999),
-    ]);
-  });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith([
+        new Date(2018, 0, 1),
+        new Date(2018, 6, 1, 23, 59, 59, 999),
+      ]);
+    });
 
-  it('calls onChange function returning a range when selected reversed two pieces of a range', () => {
-    const onChange = jest.fn();
-    const component = mount(
-      <Calendar
-        onChange={onChange}
-        selectRange
-        view="month"
-      />
-    );
+    it('calls onChange function returning a range when selected reversed two pieces of a range', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Calendar
+          onChange={onChange}
+          selectRange
+          view="month"
+        />
+      );
 
-    component.instance().onChange(new Date(2018, 6, 1));
-    component.instance().onChange(new Date(2018, 0, 1));
+      component.instance().onChange(new Date(2018, 6, 1));
+      component.instance().onChange(new Date(2018, 0, 1));
 
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith([
-      new Date(2018, 0, 1),
-      new Date(2018, 6, 1, 23, 59, 59, 999),
-    ]);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith([
+        new Date(2018, 0, 1),
+        new Date(2018, 6, 1, 23, 59, 59, 999),
+      ]);
+    });
   });
 
   it('calls onActiveDateChange on activeStartDate change', () => {
@@ -511,15 +513,100 @@ describe('Calendar', () => {
     expect(firstWeekdayTile.text()).toBe('Weekday');
   });
 
-  it('displays calendar with custom month year navigation label', () => {
-    const component = mount(
-      <Calendar
-        formatMonthYear={() => 'MonthYear'}
-      />
-    );
+  describe('formats tiles properly', () => {
+    it('displays calendar with custom month formatting', () => {
+      const component = mount(
+        <Calendar
+          formatMonth={() => 'Month'}
+          view="year"
+        />
+      );
 
-    const navigationLabel = component.find('.react-calendar__navigation__label').first();
+      const yearView = component.find('.react-calendar__year-view');
+      const firstMonthTile = yearView.find('.react-calendar__year-view__months__month').first();
 
-    expect(navigationLabel.text()).toBe('MonthYear');
+      expect(firstMonthTile.text()).toBe('Month');
+    });
+
+    it('displays calendar with custom year formatting on decade view', () => {
+      const component = mount(
+        <Calendar
+          formatYear={() => 'Year'}
+          view="decade"
+        />
+      );
+
+      const decadeView = component.find('.react-calendar__decade-view');
+      const firstYearTile = decadeView.find('.react-calendar__decade-view__years__year').first();
+
+      expect(firstYearTile.text()).toBe('Year');
+    });
+
+    it('displays calendar with custom year formatting on century view', () => {
+      const component = mount(
+        <Calendar
+          formatYear={() => 'Year'}
+          view="century"
+        />
+      );
+
+      const centuryView = component.find('.react-calendar__century-view');
+      const firstDecadeTile = centuryView.find('.react-calendar__century-view__decades__decade').first();
+
+      expect(firstDecadeTile.text()).toBe('Year – Year');
+    });
+  });
+
+  describe('formats navigation label properly', () => {
+    it('displays calendar with custom month year navigation label', () => {
+      const component = mount(
+        <Calendar
+          formatMonthYear={() => 'MonthYear'}
+        />
+      );
+
+      const navigationLabel = component.find('.react-calendar__navigation__label').first();
+
+      expect(navigationLabel.text()).toBe('MonthYear');
+    });
+
+    it('displays calendar with custom year navigation label', () => {
+      const component = mount(
+        <Calendar
+          formatYear={() => 'Year'}
+          view="year"
+        />
+      );
+
+      const navigationLabel = component.find('.react-calendar__navigation__label').first();
+
+      expect(navigationLabel.text()).toBe('Year');
+    });
+
+    it('displays calendar with custom decade navigation label', () => {
+      const component = mount(
+        <Calendar
+          formatYear={() => 'Year'}
+          view="decade"
+        />
+      );
+
+      const navigationLabel = component.find('.react-calendar__navigation__label').first();
+
+      expect(navigationLabel.text()).toBe('Year – Year');
+    });
+
+    it('displays calendar with custom century navigation label', () => {
+      const component = mount(
+        <Calendar
+          formatYear={() => 'Year'}
+          view="century"
+        />
+      );
+
+      const navigationLabel = component.find('.react-calendar__navigation__label').first();
+
+      expect(navigationLabel.text()).toBe('Year – Year');
+    });
   });
 });

--- a/src/shared/__tests__/dateFormatter.js
+++ b/src/shared/__tests__/dateFormatter.js
@@ -1,8 +1,9 @@
 import {
   formatDate,
-  formatMonthYear,
   formatMonth,
+  formatMonthYear,
   formatShortWeekday,
+  formatYear,
 } from '../dateFormatter';
 
 describe('formatDate', () => {
@@ -12,16 +13,6 @@ describe('formatDate', () => {
     const formattedDate = formatDate('en-US', date);
 
     expect(formattedDate).toBe('2/1/2017');
-  });
-});
-
-describe('formatMonthYear', () => {
-  it('returns proper month name and year', () => {
-    const date = new Date(2017, 1, 1);
-
-    const formattedDate = formatMonthYear('en-US', date);
-
-    expect(formattedDate).toBe('February 2017');
   });
 });
 
@@ -35,6 +26,16 @@ describe('formatMonth', () => {
   });
 });
 
+describe('formatMonthYear', () => {
+  it('returns proper month name and year', () => {
+    const date = new Date(2017, 1, 1);
+
+    const formattedDate = formatMonthYear('en-US', date);
+
+    expect(formattedDate).toBe('February 2017');
+  });
+});
+
 describe('formatShortWeekday', () => {
   it('returns proper short weekday name', () => {
     const date = new Date(2017, 1, 1);
@@ -42,5 +43,15 @@ describe('formatShortWeekday', () => {
     const formattedDate = formatShortWeekday('en-US', date);
 
     expect(formattedDate).toBe('Wed');
+  });
+});
+
+describe('formatYear', () => {
+  it('returns proper month name and year', () => {
+    const date = new Date(2017, 1, 1);
+
+    const formattedDate = formatYear('en-US', date);
+
+    expect(formattedDate).toBe('2017');
   });
 });

--- a/src/shared/__tests__/dates.js
+++ b/src/shared/__tests__/dates.js
@@ -1236,7 +1236,7 @@ describe('getCenturyLabel', () => {
   it('returns proper label for the century a given date is in', () => {
     const date = new Date(2017, 0, 1);
 
-    const centuryLabel = getCenturyLabel(date);
+    const centuryLabel = getCenturyLabel('en-US', undefined, date);
 
     expect(centuryLabel).toBe('2001 – 2100');
   });
@@ -1246,7 +1246,7 @@ describe('getDecadeLabel', () => {
   it('returns proper label for the decade a given date is in', () => {
     const date = new Date(2017, 0, 1);
 
-    const decadeLabel = getDecadeLabel(date);
+    const decadeLabel = getDecadeLabel('en-US', undefined, date);
 
     expect(decadeLabel).toBe('2011 – 2020');
   });

--- a/src/shared/dateFormatter.js
+++ b/src/shared/dateFormatter.js
@@ -24,14 +24,16 @@ function getSafeFormatter(options) {
 
 const formatDateOptions = { day: 'numeric', month: 'numeric', year: 'numeric' };
 const formatLongDateOptions = { day: 'numeric', month: 'long', year: 'numeric' };
-const formatMonthYearOptions = { month: 'long', year: 'numeric' };
 const formatMonthOptions = { month: 'long' };
-const formatWeekdayOptions = { weekday: 'long' };
+const formatMonthYearOptions = { month: 'long', year: 'numeric' };
+const formatYearOptions = { year: 'numeric' };
 const formatShortWeekdayOptions = { weekday: 'short' };
+const formatWeekdayOptions = { weekday: 'long' };
 
 export const formatDate = getSafeFormatter(formatDateOptions);
 export const formatLongDate = getSafeFormatter(formatLongDateOptions);
-export const formatMonthYear = getSafeFormatter(formatMonthYearOptions);
 export const formatMonth = getSafeFormatter(formatMonthOptions);
-export const formatWeekday = getSafeFormatter(formatWeekdayOptions);
+export const formatMonthYear = getSafeFormatter(formatMonthYearOptions);
+export const formatYear = getSafeFormatter(formatYearOptions);
 export const formatShortWeekday = getSafeFormatter(formatShortWeekdayOptions);
+export const formatWeekday = getSafeFormatter(formatWeekdayOptions);

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -1,3 +1,5 @@
+import { formatYear as defaultFormatYear } from './dateFormatter';
+
 const [
   // eslint-disable-next-line no-unused-vars
   SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY,
@@ -467,8 +469,8 @@ export function getDaysInMonth(date) {
   return new Date(year, monthIndex + 1, 0).getDate();
 }
 
-function toYearLabel([start, end]) {
-  return `${getYear(start)} – ${getYear(end)}`;
+function toYearLabel(locale, formatYear = defaultFormatYear, [start, end]) {
+  return `${formatYear(locale, start)} – ${formatYear(locale, end)}`;
 }
 
 /**
@@ -477,8 +479,8 @@ function toYearLabel([start, end]) {
  *
  * @param {Date|String|Number} date Date or a year as a string or as a number.
  */
-export function getCenturyLabel(date) {
-  return toYearLabel(getCenturyRange(date));
+export function getCenturyLabel(locale, formatYear, date) {
+  return toYearLabel(locale, formatYear, getCenturyRange(date));
 }
 
 /**
@@ -487,8 +489,8 @@ export function getCenturyLabel(date) {
  *
  * @param {Date|String|Number} date Date or a year as a string or as a number.
  */
-export function getDecadeLabel(date) {
-  return toYearLabel(getDecadeRange(date));
+export function getDecadeLabel(locale, formatYear, date) {
+  return toYearLabel(locale, formatYear, getDecadeRange(date));
 }
 
 /**


### PR DESCRIPTION
Fix an issue where Navigation for century view, decade view and year view would not have titles properly localized in th-TH locale
Fix an issue where Decade and Year tiles would not have labels properly localized in th-TH locale
Add support for custom formatYear function
Add new tests for formatting tiles

Fixes #238

<img width="368" alt="obraz" src="https://user-images.githubusercontent.com/5426427/65417943-8afee080-ddfb-11e9-9655-4c4d381261c4.png">

<img width="368" alt="obraz" src="https://user-images.githubusercontent.com/5426427/65417954-8fc39480-ddfb-11e9-8e7b-e10000f7dc21.png">
