### PR TITLE
defaultProps values to ES6 default params on React functional components

### DIFF
--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -22,21 +22,21 @@ const className = 'react-calendar__navigation';
 export default function Navigation({
   activeStartDate,
   drillUp,
-  formatMonthYear,
-  formatYear,
+  formatMonthYear = defaultFormatMonthYear,
+  formatYear = defaultFormatYear,
   locale,
   maxDate,
   minDate,
-  navigationAriaLabel,
+  navigationAriaLabel = '',
   navigationLabel,
-  next2AriaLabel,
-  next2Label,
-  nextAriaLabel,
-  nextLabel,
-  prev2AriaLabel,
-  prev2Label,
-  prevAriaLabel,
-  prevLabel,
+  next2AriaLabel = '',
+  next2Label = '»',
+  nextAriaLabel = '',
+  nextLabel = '›',
+  prev2AriaLabel = '',
+  prev2Label = '«',
+  prevAriaLabel = '',
+  prevLabel = '‹',
   setActiveStartDate,
   showDoubleView,
   view,
@@ -182,20 +182,6 @@ export default function Navigation({
     </div>
   );
 }
-
-Navigation.defaultProps = {
-  formatMonthYear: defaultFormatMonthYear,
-  formatYear: defaultFormatYear,
-  navigationAriaLabel: '',
-  next2AriaLabel: '',
-  next2Label: '»',
-  nextAriaLabel: '',
-  nextLabel: '›',
-  prev2AriaLabel: '',
-  prev2Label: '«',
-  prevAriaLabel: '',
-  prevLabel: '‹',
-};
 
 Navigation.propTypes = {
   activeStartDate: PropTypes.instanceOf(Date).isRequired,

--- a/src/CenturyView/Decade.jsx
+++ b/src/CenturyView/Decade.jsx
@@ -12,7 +12,7 @@ const className = 'react-calendar__century-view__decades__decade';
 export default function Decade({
   classes,
   date,
-  formatYear,
+  formatYear = defaultFormatYear,
   locale,
   ...otherProps
 }) {
@@ -30,10 +30,6 @@ export default function Decade({
     </Tile>
   );
 }
-
-Decade.defaultProps = {
-  formatYear: defaultFormatYear,
-};
 
 Decade.propTypes = {
   ...tileProps,

--- a/src/DecadeView/Year.jsx
+++ b/src/DecadeView/Year.jsx
@@ -12,7 +12,7 @@ const className = 'react-calendar__decade-view__years__year';
 export default function Year({
   classes,
   date,
-  formatYear,
+  formatYear = defaultFormatYear,
   locale,
   ...otherProps
 }) {
@@ -30,10 +30,6 @@ export default function Year({
     </Tile>
   );
 }
-
-Year.defaultProps = {
-  formatYear: defaultFormatYear,
-};
 
 Year.propTypes = {
   ...tileProps,

--- a/src/MonthView/Weekdays.jsx
+++ b/src/MonthView/Weekdays.jsx
@@ -15,7 +15,7 @@ import { isCalendarType } from '../shared/propTypes';
 export default function Weekdays(props) {
   const {
     calendarType,
-    formatShortWeekday,
+    formatShortWeekday = defaultFormatShortWeekday,
     locale,
     onMouseLeave,
   } = props;
@@ -57,10 +57,6 @@ export default function Weekdays(props) {
     </Flex>
   );
 }
-
-Weekdays.defaultProps = {
-  formatShortWeekday: defaultFormatShortWeekday,
-};
 
 Weekdays.propTypes = {
   calendarType: isCalendarType.isRequired,

--- a/src/TileGroup.jsx
+++ b/src/TileGroup.jsx
@@ -8,14 +8,14 @@ import { tileGroupProps } from './shared/propTypes';
 
 export default function TileGroup({
   className,
-  count,
+  count = 3,
   dateTransform,
   dateType,
   end,
   hover,
   offset,
   start,
-  step,
+  step = 1,
   tile: Tile,
   value,
   valueType,
@@ -58,9 +58,4 @@ TileGroup.propTypes = {
   offset: PropTypes.number,
   step: PropTypes.number,
   tile: PropTypes.func.isRequired,
-};
-
-TileGroup.defaultProps = {
-  count: 3,
-  step: 1,
 };

--- a/src/YearView/Month.jsx
+++ b/src/YearView/Month.jsx
@@ -18,7 +18,7 @@ const className = 'react-calendar__year-view__months__month';
 export default function Month({
   classes,
   date,
-  formatMonth,
+  formatMonth = defaultFormatMonth,
   locale,
   ...otherProps
 }) {
@@ -37,10 +37,6 @@ export default function Month({
     </Tile>
   );
 }
-
-Month.defaultProps = {
-  formatMonth: defaultFormatMonth,
-};
 
 Month.propTypes = {
   ...tileProps,


### PR DESCRIPTION
[React's defaultProps values](https://reactjs.org/docs/typechecking-with-proptypes.html#default-prop-values) on functional components will eventually get [deprecated](https://github.com/reactjs/rfcs/pull/107) in favor of [ES6 default parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters).  A [warning was already added](https://github.com/facebook/react/pull/16210) as a part of the process to deprecate defaultProps in functional components.

More info: [React defaultProps is dying, who’s the contender?](https://medium.com/@matanbobi/react-defaultprops-is-dying-whos-the-contender-443c19d9e7f1)