### PR TITLE
[v2.x] Hover callback, activeStartDate internal override...

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Displays a complete, interactive calendar.
 |onClickYear|Function called when the user clicks a year.|n/a|`(value) => alert('Clicked year: ', value)`|
 |onDrillDown|Function called when the user drills down by clicking a tile.|n/a|`({ activeStartDate, view }) => alert('Drilled down to: ', activeStartDate, view)`|
 |onDrillUp|Function called when the user drills up by clicking drill up button.|n/a|`({ activeStartDate, view }) => alert('Drilled up to: ', activeStartDate, view)`|
+|onMouseOutTile|Function called when the user hovers on a tile|n/a|`(value) => alert('Hovered date: ', date)`
+|onMouseOverTile|Function called when the user moves out of the tiles|n/a|`() => alert('Out !')`
 |prevAriaLabel|`aria-label` attribute of the "previous" button on the navigation pane.|n/a|`"Previous"`|
 |prevLabel|Content of the "previous" button on the navigation pane.|`"‹"`|<ul><li>String: `"‹"`</li><li>React element: `<PreviousIcon />`</li></ul>|
 |prev2AriaLabel|`aria-label` attribute of the "previous on higher level" button on the navigation pane.|n/a|`"Jump backwards"`|

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Displays a complete, interactive calendar.
 |formatMonth|Function called to override default formatting of month names. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'MMM')`|
 |formatMonthYear|Function called to override default formatting of month and year in the top navigation section. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'MMMM YYYY')`|
 |formatShortWeekday|Function called to override default formatting of weekday names. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'dd')`|
+|hoverFromProps|Date currently hovered, to bypass intern mechanism. If value is undefined, the default behaviour will be set|`undefined`|`Date` or `null`
 |keepUsingActiveStartDate|Always use the `activeStartDate` as the beginning of the period that should be displayed by default|`false`|`true` or `false`
 |locale|Locale that should be used by the calendar. Can be any [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag).|User's browser settings|`"hu-HU"`|
 |maxDate|Maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although React-Calendar will ensure that no later date is selected.|n/a|Date: `new Date()`|

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Displays a complete, interactive calendar.
 |formatMonth|Function called to override default formatting of month names. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'MMM')`|
 |formatMonthYear|Function called to override default formatting of month and year in the top navigation section. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'MMMM YYYY')`|
 |formatShortWeekday|Function called to override default formatting of weekday names. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'dd')`|
-|hover|Date currently hovered, to bypass intern mechanism. If value is undefined, the default behaviour will be set|`undefined`|`Date` or `null`
+|hover|Date currently hovered, to bypass intern mechanism. If value is undefined, the default behaviour will be set|`undefined`|`Date` or `null` or `undefined`
 |keepUsingActiveStartDate|Always use the `activeStartDate` as the beginning of the period that should be displayed by default|`false`|`true` or `false`
 |locale|Locale that should be used by the calendar. Can be any [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag).|User's browser settings|`"hu-HU"`|
 |maxDate|Maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although React-Calendar will ensure that no later date is selected.|n/a|Date: `new Date()`|

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Displays a complete, interactive calendar.
 |formatMonth|Function called to override default formatting of month names. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'MMM')`|
 |formatMonthYear|Function called to override default formatting of month and year in the top navigation section. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'MMMM YYYY')`|
 |formatShortWeekday|Function called to override default formatting of weekday names. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'dd')`|
-|hoverFromProps|Date currently hovered, to bypass intern mechanism. If value is undefined, the default behaviour will be set|`undefined`|`Date` or `null`
+|hover|Date currently hovered, to bypass intern mechanism. If value is undefined, the default behaviour will be set|`undefined`|`Date` or `null`
 |keepUsingActiveStartDate|Always use the `activeStartDate` as the beginning of the period that should be displayed by default|`false`|`true` or `false`
 |locale|Locale that should be used by the calendar. Can be any [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag).|User's browser settings|`"hu-HU"`|
 |maxDate|Maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although React-Calendar will ensure that no later date is selected.|n/a|Date: `new Date()`|

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Displays a complete, interactive calendar.
 |formatMonth|Function called to override default formatting of month names. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'MMM')`|
 |formatMonthYear|Function called to override default formatting of month and year in the top navigation section. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'MMMM YYYY')`|
 |formatShortWeekday|Function called to override default formatting of weekday names. Can be used to use your own formatting function.|(default formatter)|`(locale, date) => formatDate(date, 'dd')`|
+|keepUsingActiveStartDate|Always use the `activeStartDate` as the beginning of the period that should be displayed by default|`false`|`true` or `false`
 |locale|Locale that should be used by the calendar. Can be any [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag).|User's browser settings|`"hu-HU"`|
 |maxDate|Maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although React-Calendar will ensure that no later date is selected.|n/a|Date: `new Date()`|
 |maxDetail|The most detailed view that the user shall see. View defined here also becomes the one on which clicking an item will select a date and pass it to onChange. Can be `"month"`, `"year"`, `"decade"` or `"century"`.|`"month"`|`"year"`|

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,8 @@ declare module "react-calendar" {
     formatMonth?: FormatterCallback;
     formatMonthYear?: FormatterCallback;
     formatShortWeekday?: FormatterCallback;
+    hover?: Date
+    keepUsingActiveStartDate?: boolean
     locale?: string;
     maxDate?: Date;
     maxDetail?: Detail;

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,8 @@ declare module "react-calendar" {
     onClickYear?: DateCallback;
     onDrillDown?: ViewCallback;
     onDrillUp?: ViewCallback;
+    onMouseOverTile?: DateCallback;
+    onMouseOutTile?: () => void;
     prev2AriaLabel?: string;
     prev2Label?: string | JSX.Element | null;
     prevAriaLabel?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ declare module "react-calendar" {
     formatMonth?: FormatterCallback;
     formatMonthYear?: FormatterCallback;
     formatShortWeekday?: FormatterCallback;
-    hover?: Date
+    hover?: Date | null
     keepUsingActiveStartDate?: boolean
     locale?: string;
     maxDate?: Date;

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -383,6 +383,7 @@ export default class Calendar extends Component {
       tileClassName,
       tileContent,
       tileDisabled,
+      hover: hoverFromProps
     } = this.props;
     const {
       activeStartDate, hover, value, view,
@@ -391,7 +392,7 @@ export default class Calendar extends Component {
 
     const commonProps = {
       activeStartDate,
-      hover,
+      hover: selectRange ? hoverFromProps || hover : null,
       locale,
       maxDate,
       minDate,
@@ -547,6 +548,7 @@ export default class Calendar extends Component {
 }
 
 Calendar.defaultProps = {
+  hoverFromProps: undefined,
   keepUsingActiveStartDate: false,
   maxDetail: 'month',
   minDetail: 'century',
@@ -564,6 +566,7 @@ Calendar.propTypes = {
   formatMonth: PropTypes.func,
   formatMonthYear: PropTypes.func,
   formatShortWeekday: PropTypes.func,
+  hoverFromProps: PropTypes.func,
   locale: PropTypes.string,
   maxDate: isMaxDate,
   maxDetail: PropTypes.oneOf(allViews),
@@ -584,6 +587,8 @@ Calendar.propTypes = {
   onClickYear: PropTypes.func,
   onDrillDown: PropTypes.func,
   onDrillUp: PropTypes.func,
+  onMouseOverTile: PropTypes.func,
+  onMouseOutTile: PropTypes.func,
   prev2AriaLabel: PropTypes.string,
   prev2Label: PropTypes.node,
   prevAriaLabel: PropTypes.string,

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -147,14 +147,12 @@ const getActiveStartDate = (props) => {
   const rangeType = getView(view, minDetail, maxDetail);
 
   const valueFrom = keepUsingActiveStartDate ? (
-    getDetailValueFrom(value, minDate, maxDate, maxDetail)
-    || activeStartDate
-    || new Date()
-  ) : (
     activeStartDate
     || getDetailValueFrom(value, minDate, maxDate, maxDetail)
-    || new Date()
-  );
+  ) : (
+    getDetailValueFrom(value, minDate, maxDate, maxDetail)
+    || activeStartDate
+  ) || new Date();
   return getBegin(rangeType, valueFrom);
 };
 
@@ -383,16 +381,16 @@ export default class Calendar extends Component {
       tileClassName,
       tileContent,
       tileDisabled,
-      hover: hoverFromProps
+      hover,
     } = this.props;
     const {
-      activeStartDate, hover, value, view,
+      activeStartDate, hover: hoverFromState, value, view,
     } = this.state;
     const { onMouseOver, valueType } = this;
 
     const commonProps = {
       activeStartDate,
-      hover: selectRange ? hoverFromProps || hover : null,
+      hover: selectRange ? hover || hoverFromState : null,
       locale,
       maxDate,
       minDate,
@@ -548,7 +546,7 @@ export default class Calendar extends Component {
 }
 
 Calendar.defaultProps = {
-  hoverFromProps: undefined,
+  hover: undefined,
   keepUsingActiveStartDate: false,
   maxDetail: 'month',
   minDetail: 'century',
@@ -562,11 +560,11 @@ Calendar.propTypes = {
   activeStartDate: PropTypes.instanceOf(Date),
   calendarType: isCalendarType,
   className: isClassName,
-  keepUsingActiveStartDate: PropTypes.bool,
   formatMonth: PropTypes.func,
   formatMonthYear: PropTypes.func,
   formatShortWeekday: PropTypes.func,
-  hoverFromProps: PropTypes.func,
+  hover: PropTypes.func,
+  keepUsingActiveStartDate: PropTypes.bool,
   locale: PropTypes.string,
   maxDate: isMaxDate,
   maxDetail: PropTypes.oneOf(allViews),
@@ -587,8 +585,8 @@ Calendar.propTypes = {
   onClickYear: PropTypes.func,
   onDrillDown: PropTypes.func,
   onDrillUp: PropTypes.func,
-  onMouseOverTile: PropTypes.func,
   onMouseOutTile: PropTypes.func,
+  onMouseOverTile: PropTypes.func,
   prev2AriaLabel: PropTypes.string,
   prev2Label: PropTypes.node,
   prevAriaLabel: PropTypes.string,

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -568,7 +568,10 @@ Calendar.propTypes = {
   formatMonth: PropTypes.func,
   formatMonthYear: PropTypes.func,
   formatShortWeekday: PropTypes.func,
-  hover: PropTypes.func,
+  hover: PropTypes.oneOfType([
+    PropTypes.instanceOf(Date),
+    PropTypes.oneOf([null]),
+  ]),
   keepUsingActiveStartDate: PropTypes.bool,
   locale: PropTypes.string,
   maxDate: isMaxDate,

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -357,8 +357,8 @@ export default class Calendar extends Component {
   }
 
   onMouseOver = (value) => {
-    const { onMouseOverTile } = this.props
-    callIfDefined(onMouseOverTile, value)
+    const { onMouseOverTile } = this.props;
+    callIfDefined(onMouseOverTile, value);
     this.setState((prevState) => {
       if (prevState.hover && (prevState.hover.getTime() === value.getTime())) {
         return null;
@@ -370,8 +370,8 @@ export default class Calendar extends Component {
   }
 
   onMouseLeave = () => {
-    const { onMouseOutTile } = this.props
-    callIfDefined(onMouseOutTile)
+    const { onMouseOutTile } = this.props;
+    callIfDefined(onMouseOutTile);
     this.setState({ hover: null });
   }
 

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -135,6 +135,7 @@ const getDetailValueArray = (value, minDate, maxDate, maxDetail) => {
 const getActiveStartDate = (props) => {
   const {
     activeStartDate,
+    keepUsingActiveStartDate,
     maxDate,
     maxDetail,
     minDate,
@@ -144,9 +145,14 @@ const getActiveStartDate = (props) => {
   } = props;
 
   const rangeType = getView(view, minDetail, maxDetail);
-  const valueFrom = (
+
+  const valueFrom = keepUsingActiveStartDate ? (
     getDetailValueFrom(value, minDate, maxDate, maxDetail)
     || activeStartDate
+    || new Date()
+  ) : (
+    activeStartDate
+    || getDetailValueFrom(value, minDate, maxDate, maxDetail)
     || new Date()
   );
   return getBegin(rangeType, valueFrom);
@@ -541,6 +547,7 @@ export default class Calendar extends Component {
 }
 
 Calendar.defaultProps = {
+  keepUsingActiveStartDate: false,
   maxDetail: 'month',
   minDetail: 'century',
   returnValue: 'start',
@@ -553,6 +560,7 @@ Calendar.propTypes = {
   activeStartDate: PropTypes.instanceOf(Date),
   calendarType: isCalendarType,
   className: isClassName,
+  keepUsingActiveStartDate: PropTypes.bool,
   formatMonth: PropTypes.func,
   formatMonthYear: PropTypes.func,
   formatShortWeekday: PropTypes.func,

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -357,16 +357,21 @@ export default class Calendar extends Component {
   }
 
   onMouseOver = (value) => {
+    const { onMouseOverTile } = this.props
+    callIfDefined(onMouseOverTile, value)
     this.setState((prevState) => {
       if (prevState.hover && (prevState.hover.getTime() === value.getTime())) {
         return null;
       }
+
 
       return { hover: value };
     });
   }
 
   onMouseLeave = () => {
+    const { onMouseOutTile } = this.props
+    callIfDefined(onMouseOutTile)
     this.setState({ hover: null });
   }
 

--- a/src/__tests__/Calendar.jsx
+++ b/src/__tests__/Calendar.jsx
@@ -540,13 +540,13 @@ describe('Calendar', () => {
 
     const component = mount(
       <Calendar
-        onMouseOverTile={onOver}
         onMouseOutTile={onOut}
+        onMouseOverTile={onOver}
         selectRange
         view="month"
       />
     );
-    const viewContainer = component.find('.react-calendar__viewContainer')
+    const viewContainer = component.find('.react-calendar__viewContainer');
     const monthView = component.find('.react-calendar__month-view');
     const firstDayTile = monthView.find('.react-calendar__tile').first();
     firstDayTile.simulate('mouseover');

--- a/src/__tests__/Calendar.jsx
+++ b/src/__tests__/Calendar.jsx
@@ -498,6 +498,29 @@ describe('Calendar', () => {
     expect(firstDayTileTimeAbbr).toBe(format(newActiveStartDate));
   });
 
+  it('does not changes Calendar view given new value', () => {
+    const getFirstDayTileLabel = (cmp) => {
+      const monthView = cmp.find('.react-calendar__month-view');
+      const firstDayTile = monthView.find('.react-calendar__tile').first();
+      const firstDayTileTimeAbbr = firstDayTile.find('abbr').prop('aria-label');
+      return firstDayTileTimeAbbr;
+    };
+
+    const activeStartDate = new Date(2017, 0, 1);
+    const expectedFirstDate = new Date(2016, 11, 26);
+    const nextValue = new Date(2017, 3, 1);
+
+    const component = mount(
+      <Calendar activeStartDate={activeStartDate} keepUsingActiveStartDate view="month" />
+    );
+
+    expect(getFirstDayTileLabel(component)).toBe(format(expectedFirstDate));
+
+    component.setProps({ value: nextValue });
+
+    expect(getFirstDayTileLabel(component)).toBe(format(expectedFirstDate));
+  });
+
   it('displays calendar with custom weekdays formatting', () => {
     const component = mount(
       <Calendar

--- a/src/__tests__/Calendar.jsx
+++ b/src/__tests__/Calendar.jsx
@@ -534,6 +534,28 @@ describe('Calendar', () => {
     expect(firstWeekdayTile.text()).toBe('Weekday');
   });
 
+  it('calls onTileOver / onTileOut function if provided with the current hovered date', () => {
+    const onOver = jest.fn();
+    const onOut = jest.fn();
+
+    const component = mount(
+      <Calendar
+        onMouseOverTile={onOver}
+        onMouseOutTile={onOut}
+        selectRange
+        view="month"
+      />
+    );
+    const viewContainer = component.find('.react-calendar__viewContainer')
+    const monthView = component.find('.react-calendar__month-view');
+    const firstDayTile = monthView.find('.react-calendar__tile').first();
+    firstDayTile.simulate('mouseover');
+    viewContainer.simulate('mouseleave');
+
+    expect(onOver).toHaveBeenCalledTimes(1);
+    expect(onOut).toHaveBeenCalledTimes(1);
+  });
+
   it('displays calendar with custom month year navigation label', () => {
     const component = mount(
       <Calendar


### PR DESCRIPTION
Hi !

I don't know If you still maintain the v2 but for my own needs, I had to implement some features:
* the ability to programatically control the date hovered
* disable the fact that when you specify a date not shown on the current view, the calendar will render the view where this specific date is visible.

It allow me to do things like that...
<img width="1431" alt="Capture d’écran 2019-11-27 à 18 53 06" src="https://user-images.githubusercontent.com/16650656/69748437-a6160580-1148-11ea-8e43-faeb31fbe79e.png">
<img width="1431" alt="Capture d’écran 2019-11-27 à 18 53 08" src="https://user-images.githubusercontent.com/16650656/69748445-ac0be680-1148-11ea-9bdb-be769a5041ab.png">

