### PR TITLE
Fixed re-rendering issue in Calendar component

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -435,7 +435,6 @@ export default class Calendar extends Component {
           showFixedNumberOfWeeks,
           showNeighboringMonth,
           showWeekNumbers,
-          selectRange
         } = this.props;
         const { onMouseLeave } = this;
 

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -435,6 +435,7 @@ export default class Calendar extends Component {
           showFixedNumberOfWeeks,
           showNeighboringMonth,
           showWeekNumbers,
+          selectRange
         } = this.props;
         const { onMouseLeave } = this;
 
@@ -444,7 +445,7 @@ export default class Calendar extends Component {
             formatLongDate={formatLongDate}
             formatShortWeekday={formatShortWeekday}
             onClickWeekNumber={onClickWeekNumber}
-            onMouseLeave={onMouseLeave}
+            onMouseLeave={selectRange ? onMouseLeave : null}
             showFixedNumberOfWeeks={showFixedNumberOfWeeks || showDoubleView}
             showNeighboringMonth={showNeighboringMonth}
             showWeekNumbers={showWeekNumbers}


### PR DESCRIPTION
The `onMouseLeave` prop of `<MonthView/>` should be `null` when `selectRange` is not set. It is causing unnecessary re-rendering of the whole `<Calendar/>` component on the hover of `<Weekdays/>` component (child of `<MonthView/>` ) due to fire of the `onMouseOver` event passed in its child `<Flex/>` .