### PR TITLE
Add class names to Navigation label items to allow custom styling

### DIFF
--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -155,13 +155,17 @@ export default function Navigation({
         style={{ flexGrow: 1 }}
         type="button"
       >
-        {renderLabel(activeStartDate)}
+        <span className={`${className}__activeStartDateLabel`}>
+          {renderLabel(activeStartDate)}
+        </span>
         {showDoubleView && (
           <>
-            {' '}
-            –
-            {' '}
-            {renderLabel(nextActiveStartDate)}
+            <span className={`${className}__doubleViewDatesSeparator`}>
+              -
+            </span>
+            <span className={`${className}__nextActiveStartDateLabel`}>
+              {renderLabel(nextActiveStartDate)}
+            </span>
           </>
         )}
       </button>

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -122,6 +122,36 @@ export default function Navigation({
     );
   }
 
+  function renderButton() {
+    const labelClassName = `${className}__label`;
+    return (
+      <button
+        aria-label={navigationAriaLabel}
+        className={labelClassName}
+        disabled={!drillUpAvailable}
+        onClick={drillUp}
+        style={{ flexGrow: 1 }}
+        type="button"
+      >
+        <span className={`${labelClassName}__labelText ${labelClassName}__labelText--from`}>
+          {renderLabel(activeStartDate)}
+        </span>
+        {showDoubleView && (
+          <>
+            <span className={`${labelClassName}__divider`}>
+              {' '}
+              –
+              {' '}
+            </span>
+            <span className={`${labelClassName}__labelText ${labelClassName}__labelText--to`}>
+              {renderLabel(nextActiveStartDate)}
+            </span>
+          </>
+        )}
+      </button>
+    );
+  }
+
   return (
     <div
       className={className}
@@ -147,30 +177,7 @@ export default function Navigation({
       >
         {prevLabel}
       </button>
-      <button
-        aria-label={navigationAriaLabel}
-        className={`${className}__label`}
-        disabled={!drillUpAvailable}
-        onClick={drillUp}
-        style={{ flexGrow: 1 }}
-        type="button"
-      >
-        <span className={`${className}__activeStartDateLabel`}>
-          {renderLabel(activeStartDate)}
-        </span>
-        {showDoubleView && (
-          <>
-            <span className={`${className}__doubleViewDatesSeparator`}>
-              {' '}
-              –
-              {' '}
-            </span>
-            <span className={`${className}__nextActiveStartDateLabel`}>
-              {renderLabel(nextActiveStartDate)}
-            </span>
-          </>
-        )}
-      </button>
+      {renderButton()}
       <button
         aria-label={nextAriaLabel}
         className={`${className}__arrow ${className}__next-button`}

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -162,7 +162,7 @@ export default function Navigation({
           <>
             <span className={`${className}__doubleViewDatesSeparator`}>
               {' '}
-              -
+              –
               {' '}
             </span>
             <span className={`${className}__nextActiveStartDateLabel`}>

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -161,7 +161,9 @@ export default function Navigation({
         {showDoubleView && (
           <>
             <span className={`${className}__doubleViewDatesSeparator`}>
+              {' '}
               -
+              {' '}
             </span>
             <span className={`${className}__nextActiveStartDateLabel`}>
               {renderLabel(nextActiveStartDate)}


### PR DESCRIPTION
Hi,

I send you this PR to allow users to style the separation text between two dates in `showDoubleView` mode. More correct approach would be to also allow for custom text in that separator, but I thought I'd keep it simple for you to evaluate. 

Thank you