### PR TITLE
Don't call onActiveStartDateChange, onViewChange, onChange if the values didn't change

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -255,7 +255,7 @@ export default class Calendar extends Component {
       onActiveStartDateChange, onChange, onViewChange, selectRange,
     } = this.props;
 
-    const prevState = {
+    const prevArgs = {
       activeStartDate: previousActiveStartDate,
       view: previousView,
     };
@@ -267,7 +267,20 @@ export default class Calendar extends Component {
       };
 
       function shouldUpdate(key) {
-        return key in nextState && nextState[key] !== prevState[key];
+        return (
+          // Key must exist, and…
+          key in nextState
+          && (
+            // …key changed from undefined to defined or the other way around, or…
+            typeof nextState[key] !== typeof prevArgs[key]
+            // …value changed.
+            || (
+              nextState[key] instanceof Date
+                ? nextState[key].getTime() !== prevArgs[key].getTime()
+                : nextState[key] !== prevArgs[key]
+            )
+          )
+        );
       }
 
       if (shouldUpdate('activeStartDate')) {

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -247,8 +247,18 @@ export default class Calendar extends Component {
 
   setStateAndCallCallbacks = (nextState, callback) => {
     const {
+      activeStartDate: previousActiveStartDate,
+      view: previousView,
+    } = this;
+
+    const {
       onActiveStartDateChange, onChange, onViewChange, selectRange,
     } = this.props;
+
+    const prevState = {
+      activeStartDate: previousActiveStartDate,
+      view: previousView,
+    };
 
     this.setState(nextState, () => {
       const args = {
@@ -256,15 +266,19 @@ export default class Calendar extends Component {
         view: nextState.view || this.view,
       };
 
-      if ('activeStartDate' in nextState) {
+      function shouldUpdate(key) {
+        return key in nextState && nextState[key] !== prevState[key];
+      }
+
+      if (shouldUpdate('activeStartDate')) {
         callIfDefined(onActiveStartDateChange, args);
       }
 
-      if ('view' in nextState) {
+      if (shouldUpdate('view')) {
         callIfDefined(onViewChange, args);
       }
 
-      if ('value' in nextState) {
+      if (shouldUpdate('value')) {
         if (!selectRange || !isSingleValue(nextState.value)) {
           callIfDefined(onChange, nextState.value);
         }

--- a/src/Calendar.spec.jsx
+++ b/src/Calendar.spec.jsx
@@ -485,6 +485,24 @@ describe('Calendar', () => {
       expect(component.instance().activeStartDate).toEqual(new Date(2019, 0, 1));
     });
 
+    it('calls onActiveStartDateChange on activeStartDate initial set', () => {
+      const newActiveStartDate = new Date(2018, 0, 1);
+      const onActiveStartDateChange = jest.fn();
+      const component = shallow(
+        <Calendar
+          onActiveStartDateChange={onActiveStartDateChange}
+          view="year"
+        />,
+      );
+
+      component.instance().setActiveStartDate(newActiveStartDate);
+
+      expect(onActiveStartDateChange).toHaveBeenCalledWith({
+        activeStartDate: newActiveStartDate,
+        view: 'year',
+      });
+    });
+
     it('calls onActiveStartDateChange on activeStartDate change', () => {
       const activeStartDate = new Date(2017, 0, 1);
       const newActiveStartDate = new Date(2018, 0, 1);
@@ -507,7 +525,7 @@ describe('Calendar', () => {
 
     it('does not call onActiveStartDateChange on activeStartDate change if value is the same as before', () => {
       const activeStartDate = new Date(2017, 0, 1);
-      const newActiveStartDate = activeStartDate;
+      const newActiveStartDate = new Date(2017, 0, 1);
       const onActiveStartDateChange = jest.fn();
       const component = shallow(
         <Calendar
@@ -524,6 +542,25 @@ describe('Calendar', () => {
   });
 
   describe('handles view change properly', () => {
+    it('calls onViewChange on view initial set', () => {
+      const activeStartDate = new Date(2017, 0, 1);
+      const newView = 'year';
+      const onViewChange = jest.fn();
+      const component = shallow(
+        <Calendar
+          activeStartDate={activeStartDate}
+          onViewChange={onViewChange}
+        />,
+      );
+
+      component.instance().setStateAndCallCallbacks({ view: newView });
+
+      expect(onViewChange).toHaveBeenCalledWith({
+        activeStartDate,
+        view: newView,
+      });
+    });
+
     it('calls onViewChange on view change', () => {
       const activeStartDate = new Date(2017, 0, 1);
       const view = 'year';
@@ -548,7 +585,7 @@ describe('Calendar', () => {
     it('does not call onViewChange on view change if value is the same as before', () => {
       const activeStartDate = new Date(2017, 0, 1);
       const view = 'year';
-      const newView = view;
+      const newView = 'year';
       const onViewChange = jest.fn();
       const component = shallow(
         <Calendar

--- a/src/Calendar.spec.jsx
+++ b/src/Calendar.spec.jsx
@@ -504,6 +504,64 @@ describe('Calendar', () => {
         view: 'year',
       });
     });
+
+    it('does not call onActiveStartDateChange on activeStartDate change if value is the same as before', () => {
+      const activeStartDate = new Date(2017, 0, 1);
+      const newActiveStartDate = activeStartDate;
+      const onActiveStartDateChange = jest.fn();
+      const component = shallow(
+        <Calendar
+          activeStartDate={activeStartDate}
+          onActiveStartDateChange={onActiveStartDateChange}
+          view="year"
+        />,
+      );
+
+      component.instance().setActiveStartDate(newActiveStartDate);
+
+      expect(onActiveStartDateChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handles view change properly', () => {
+    it('calls onViewChange on view change', () => {
+      const activeStartDate = new Date(2017, 0, 1);
+      const view = 'year';
+      const newView = 'month';
+      const onViewChange = jest.fn();
+      const component = shallow(
+        <Calendar
+          activeStartDate={activeStartDate}
+          onViewChange={onViewChange}
+          view={view}
+        />,
+      );
+
+      component.instance().setStateAndCallCallbacks({ view: newView });
+
+      expect(onViewChange).toHaveBeenCalledWith({
+        activeStartDate,
+        view: newView,
+      });
+    });
+
+    it('does not call onViewChange on view change if value is the same as before', () => {
+      const activeStartDate = new Date(2017, 0, 1);
+      const view = 'year';
+      const newView = view;
+      const onViewChange = jest.fn();
+      const component = shallow(
+        <Calendar
+          activeStartDate={activeStartDate}
+          onViewChange={onViewChange}
+          view={view}
+        />,
+      );
+
+      component.instance().setStateAndCallCallbacks({ view: newView });
+
+      expect(onViewChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('calls onChange properly', () => {


### PR DESCRIPTION
Fixes #343 