### PR TITLE
Fix a typo in a Navigation test that's causing it to fail

### DIFF
--- a/src/Calendar/Navigation.spec.jsx
+++ b/src/Calendar/Navigation.spec.jsx
@@ -494,7 +494,7 @@ describe('Navigation', () => {
       locale,
       date,
       view,
-      label: 'Januar 2017',
+      label: 'January 2017',
     });
     expect(drillUp.text()).toBe(label);
   });


### PR DESCRIPTION
This test is currently failing because there is a typo in the label. `Januar` should be `January`.