### PR TITLE
Add hoverStart/hoverEnd CSS classes to style hovered date range

### DIFF
--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -90,6 +90,27 @@ export function getTileClasses({
     classes.push(`${className}--hover`);
   }
 
+  if (hover) {
+    const hoverRange = [
+      Math.min(valueRange[0], hover),
+      Math.max(valueRange[1], hover),
+    ];
+    const isHoverRangeStart = isValueWithinRange(hoverRange[0], dateRange);
+    const isHoverRangeEnd = isValueWithinRange(hoverRange[1], dateRange);
+
+    if (isHoverRangeStart) {
+      classes.push(`${className}--hoverRangeStart`);
+    }
+
+    if (isHoverRangeEnd) {
+      classes.push(`${className}--hoverRangeEnd`);
+    }
+
+    if (isHoverRangeStart && isHoverRangeEnd) {
+      classes.push(`${className}--hoverRangeBothEnds`);
+    }
+  }
+
   const isRangeStart = isValueWithinRange(valueRange[0], dateRange);
   const isRangeEnd = isValueWithinRange(valueRange[1], dateRange);
 

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -38,6 +38,33 @@ export function doRangesOverlap(range1, range2) {
   );
 }
 
+function getRangeClassNames(valueRange, dateRange, baseClassName) {
+  const isRange = doRangesOverlap(dateRange, valueRange);
+
+  const classes = [];
+
+  if (isRange) {
+    classes.push(baseClassName);
+
+    const isRangeStart = isValueWithinRange(valueRange[0], dateRange);
+    const isRangeEnd = isValueWithinRange(valueRange[1], dateRange);
+
+    if (isRangeStart) {
+      classes.push(`${baseClassName}Start`);
+    }
+
+    if (isRangeEnd) {
+      classes.push(`${baseClassName}End`);
+    }
+
+    if (isRangeStart && isRangeEnd) {
+      classes.push(`${baseClassName}BothEnds`);
+    }
+  }
+
+  return classes;
+}
+
 export function getTileClasses({
   value, valueType, date, dateType, hover,
 } = {}) {
@@ -73,57 +100,17 @@ export function getTileClasses({
     classes.push(`${className}--active`);
   } else if (doRangesOverlap(valueRange, dateRange)) {
     classes.push(`${className}--hasActive`);
-  } else if (
-    hover && (
-      // Date before value
-      (
-        dateRange[1] < valueRange[0]
-        && doRangesOverlap(dateRange, [hover, valueRange[0]])
-      )
-      // Date after value
-      || (
-        dateRange[0] > valueRange[1]
-        && doRangesOverlap(dateRange, [valueRange[1], hover])
-      )
-    )
-  ) {
-    classes.push(`${className}--hover`);
   }
+
+  const valueRangeClassNames = getRangeClassNames(valueRange, dateRange, `${className}--range`);
+
+  classes.push(...valueRangeClassNames);
 
   if (hover) {
-    const hoverRange = [
-      Math.min(valueRange[0], hover),
-      Math.max(valueRange[1], hover),
-    ];
-    const isHoverRangeStart = isValueWithinRange(hoverRange[0], dateRange);
-    const isHoverRangeEnd = isValueWithinRange(hoverRange[1], dateRange);
+    const hoverRange = hover > valueRange[1] ? [valueRange[1], hover] : [hover, valueRange[0]];
+    const hoverRangeClassNames = getRangeClassNames(hoverRange, dateRange, `${className}--hover`);
 
-    if (isHoverRangeStart) {
-      classes.push(`${className}--hoverRangeStart`);
-    }
-
-    if (isHoverRangeEnd) {
-      classes.push(`${className}--hoverRangeEnd`);
-    }
-
-    if (isHoverRangeStart && isHoverRangeEnd) {
-      classes.push(`${className}--hoverRangeBothEnds`);
-    }
-  }
-
-  const isRangeStart = isValueWithinRange(valueRange[0], dateRange);
-  const isRangeEnd = isValueWithinRange(valueRange[1], dateRange);
-
-  if (isRangeStart) {
-    classes.push(`${className}--rangeStart`);
-  }
-
-  if (isRangeEnd) {
-    classes.push(`${className}--rangeEnd`);
-  }
-
-  if (isRangeStart && isRangeEnd) {
-    classes.push(`${className}--rangeBothEnds`);
+    classes.push(...hoverRangeClassNames);
   }
 
   return classes;

--- a/src/shared/utils.spec.js
+++ b/src/shared/utils.spec.js
@@ -224,34 +224,6 @@ describe('getTileClasses', () => {
     expect(result.includes('react-calendar__tile--hover')).toBe(false);
   });
 
-  it('returns hover flag set to true when passed a date between value and hover (1)', () => {
-    const result = getTileClasses({
-      value: new Date(2017, 6, 1),
-      valueType: 'month',
-      date: new Date(2017, 3, 1),
-      dateType: 'month',
-      hover: new Date(2017, 0, 1),
-    });
-
-    expect(result.includes('react-calendar__tile--active')).toBe(false);
-    expect(result.includes('react-calendar__tile--hasActive')).toBe(false);
-    expect(result.includes('react-calendar__tile--hover')).toBe(true);
-  });
-
-  it('returns hover flag set to true when passed a date between value and hover (2)', () => {
-    const result = getTileClasses({
-      value: new Date(2017, 0, 1),
-      valueType: 'month',
-      date: new Date(2017, 3, 1),
-      dateType: 'month',
-      hover: new Date(2017, 6, 1),
-    });
-
-    expect(result.includes('react-calendar__tile--active')).toBe(false);
-    expect(result.includes('react-calendar__tile--hasActive')).toBe(false);
-    expect(result.includes('react-calendar__tile--hover')).toBe(true);
-  });
-
   it('returns all flags set to false when given value completely unrelated to date', () => {
     const result = getTileClasses({
       value: new Date(2017, 6, 1),
@@ -262,6 +234,104 @@ describe('getTileClasses', () => {
 
     expect(result.includes('react-calendar__tile--active')).toBe(false);
     expect(result.includes('react-calendar__tile--hasActive')).toBe(false);
-    expect(result.includes('react-calendar__tile--hover')).toBe(false);
+  });
+
+  describe('range classes', () => {
+    it('returns range flag set to true when passed a date within value array', () => {
+      const result = getTileClasses({
+        value: [new Date(2017, 0, 1), new Date(2017, 6, 1)],
+        valueType: 'month',
+        date: new Date(2017, 3, 1),
+        dateType: 'month',
+      });
+
+      expect(result.includes('react-calendar__tile--range')).toBe(true);
+      expect(result.includes('react-calendar__tile--rangeStart')).toBe(false);
+      expect(result.includes('react-calendar__tile--rangeEnd')).toBe(false);
+    });
+
+    it('returns range & rangeStart flags set to true when passed a date equal to value start', () => {
+      const result = getTileClasses({
+        value: [new Date(2017, 0, 1), new Date(2017, 6, 1)],
+        valueType: 'month',
+        date: new Date(2017, 0, 1),
+        dateType: 'month',
+      });
+
+      expect(result.includes('react-calendar__tile--range')).toBe(true);
+      expect(result.includes('react-calendar__tile--rangeStart')).toBe(true);
+      expect(result.includes('react-calendar__tile--rangeEnd')).toBe(false);
+    });
+
+    it('returns range & rangeEnd flags set to true when passed a date equal to value end', () => {
+      const result = getTileClasses({
+        value: [new Date(2017, 0, 1), new Date(2017, 6, 1)],
+        valueType: 'month',
+        date: new Date(2017, 6, 1),
+        dateType: 'month',
+      });
+
+      expect(result.includes('react-calendar__tile--range')).toBe(true);
+      expect(result.includes('react-calendar__tile--rangeStart')).toBe(false);
+      expect(result.includes('react-calendar__tile--rangeEnd')).toBe(true);
+    });
+  });
+
+  describe('hover classes', () => {
+    it('returns hover flag set to true when passed a date between value and hover (1)', () => {
+      const result = getTileClasses({
+        value: new Date(2017, 6, 1),
+        valueType: 'month',
+        date: new Date(2017, 3, 1),
+        dateType: 'month',
+        hover: new Date(2017, 0, 1),
+      });
+
+      expect(result.includes('react-calendar__tile--hover')).toBe(true);
+      expect(result.includes('react-calendar__tile--hoverStart')).toBe(false);
+      expect(result.includes('react-calendar__tile--hoverEnd')).toBe(false);
+    });
+
+    it('returns hover flag set to true when passed a date between value and hover (2)', () => {
+      const result = getTileClasses({
+        value: new Date(2017, 0, 1),
+        valueType: 'month',
+        date: new Date(2017, 3, 1),
+        dateType: 'month',
+        hover: new Date(2017, 6, 1),
+      });
+
+      expect(result.includes('react-calendar__tile--hover')).toBe(true);
+      expect(result.includes('react-calendar__tile--hoverStart')).toBe(false);
+      expect(result.includes('react-calendar__tile--hoverEnd')).toBe(false);
+    });
+
+    it('returns hover & hoverStart flags set to true when passed a date equal to hover', () => {
+      const result = getTileClasses({
+        value: new Date(2017, 0, 1),
+        valueType: 'month',
+        date: new Date(2017, 0, 1),
+        dateType: 'month',
+        hover: new Date(2017, 6, 1),
+      });
+
+      expect(result.includes('react-calendar__tile--hover')).toBe(true);
+      expect(result.includes('react-calendar__tile--hoverStart')).toBe(true);
+      expect(result.includes('react-calendar__tile--hoverEnd')).toBe(false);
+    });
+
+    it('returns hover & hoverEnd flags set to true when passed a date equal to hover', () => {
+      const result = getTileClasses({
+        value: new Date(2017, 0, 1),
+        valueType: 'month',
+        date: new Date(2017, 6, 1),
+        dateType: 'month',
+        hover: new Date(2017, 6, 1),
+      });
+
+      expect(result.includes('react-calendar__tile--hover')).toBe(true);
+      expect(result.includes('react-calendar__tile--hoverStart')).toBe(false);
+      expect(result.includes('react-calendar__tile--hoverEnd')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1434481/81511733-4fece700-92d0-11ea-99fe-5d00dedb98d5.png)

I'm trying to style react-calendar so that the start and end of a range _in-progress_ has rounded corners. Currently, react-calendar only exposes the start and end of the confirmed range (i.e. the range that's in `value`). This PR exposes the start and end of the _unconfirmed_ range via `hoverRangeStart`, `hoverRangeEnd`, and `hoverRangeBothEnds` CSS classes.

I named them hoverRange because it seemed consistent with the current `--hover` class, but I'm happy to rename them as you see fit.

Thanks!