### PR TITLE
Add value to onActiveStartDateChange and onViewChange callbacks arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ Displays a complete, interactive calendar.
 |nextLabel|Content of the "next" button on the navigation pane. Setting the value explicitly to null will hide the icon.|`"›"`|<ul><li>String: `"›"`</li><li>React element: `<NextIcon />`</li></ul>|
 |next2AriaLabel|`aria-label` attribute of the "next on higher level" button on the navigation pane.|n/a|`"Jump forwards"`|
 |next2Label|Content of the "next on higher level" button on the navigation pane. Setting the value explicitly to null will hide the icon.|`"»"`|<ul><li>String: `"»"`</li><li>React element: `<DoubleNextIcon />`</li></ul>|
-|onActiveStartDateChange|Function called when the user navigates from one view to another using previous/next button.|n/a|`({ activeStartDate, view }) => alert('Changed view to: ', activeStartDate, view)`|
+|onActiveStartDateChange|Function called when the user navigates from one view to another using previous/next button.|n/a|`({ activeStartDate, value, view }) => alert('Changed view to: ', activeStartDate, view)`|
 |onChange|Function called when the user clicks an item (day on month view, month on year view and so on) on the most detailed view available.|n/a|`(value, event) => alert('New date is: ', value)`|
-|onViewChange|Function called when the user navigates from one view to another using drill up button or by clicking a tile.|n/a|`({ activeStartDate, view }) => alert('New view is: ', view)`|
+|onViewChange|Function called when the user navigates from one view to another using drill up button or by clicking a tile.|n/a|`({ activeStartDate, value, view }) => alert('New view is: ', view)`|
 |onClickDay|Function called when the user clicks a day.|n/a|`(value, event) => alert('Clicked day: ', value)`|
 |onClickDecade|Function called when the user clicks a decade.|n/a|`(value, event) => alert('Clicked decade: ', value)`|
 |onClickMonth|Function called when the user clicks a month.|n/a|`(value, event) => alert('Clicked month: ', value)`|

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -266,6 +266,7 @@ export default class Calendar extends Component {
     this.setState(nextState, () => {
       const args = {
         activeStartDate: nextState.activeStartDate || this.activeStartDate,
+        value: nextState.value || this.value,
         view: nextState.view || this.view,
       };
 

--- a/src/Calendar.spec.jsx
+++ b/src/Calendar.spec.jsx
@@ -514,11 +514,13 @@ describe('Calendar', () => {
     });
 
     it('calls onActiveStartDateChange on activeStartDate initial set', () => {
+      const value = new Date(2019, 0, 15);
       const newActiveStartDate = new Date(2018, 0, 1);
       const onActiveStartDateChange = jest.fn();
       const component = shallow(
         <Calendar
           onActiveStartDateChange={onActiveStartDateChange}
+          value={value}
           view="year"
         />,
       );
@@ -527,11 +529,13 @@ describe('Calendar', () => {
 
       expect(onActiveStartDateChange).toHaveBeenCalledWith({
         activeStartDate: newActiveStartDate,
+        value,
         view: 'year',
       });
     });
 
     it('calls onActiveStartDateChange on activeStartDate change', () => {
+      const value = new Date(2019, 0, 15);
       const activeStartDate = new Date(2017, 0, 1);
       const newActiveStartDate = new Date(2018, 0, 1);
       const onActiveStartDateChange = jest.fn();
@@ -539,6 +543,7 @@ describe('Calendar', () => {
         <Calendar
           activeStartDate={activeStartDate}
           onActiveStartDateChange={onActiveStartDateChange}
+          value={value}
           view="year"
         />,
       );
@@ -547,6 +552,7 @@ describe('Calendar', () => {
 
       expect(onActiveStartDateChange).toHaveBeenCalledWith({
         activeStartDate: newActiveStartDate,
+        value,
         view: 'year',
       });
     });
@@ -571,6 +577,7 @@ describe('Calendar', () => {
 
   describe('handles view change properly', () => {
     it('calls onViewChange on view initial set', () => {
+      const value = new Date(2019, 0, 15);
       const activeStartDate = new Date(2017, 0, 1);
       const newView = 'year';
       const onViewChange = jest.fn();
@@ -578,6 +585,7 @@ describe('Calendar', () => {
         <Calendar
           activeStartDate={activeStartDate}
           onViewChange={onViewChange}
+          value={value}
         />,
       );
 
@@ -585,11 +593,13 @@ describe('Calendar', () => {
 
       expect(onViewChange).toHaveBeenCalledWith({
         activeStartDate,
+        value,
         view: newView,
       });
     });
 
     it('calls onViewChange on view change', () => {
+      const value = new Date(2019, 0, 15);
       const activeStartDate = new Date(2017, 0, 1);
       const view = 'year';
       const newView = 'month';
@@ -598,6 +608,7 @@ describe('Calendar', () => {
         <Calendar
           activeStartDate={activeStartDate}
           onViewChange={onViewChange}
+          value={value}
           view={view}
         />,
       );
@@ -606,6 +617,7 @@ describe('Calendar', () => {
 
       expect(onViewChange).toHaveBeenCalledWith({
         activeStartDate,
+        value,
         view: newView,
       });
     });


### PR DESCRIPTION
This will make it much easier to programatically determine why a given callback was called.

For example, if `value` in `onActiveStartDateChange` remains the same, we know that it's not the calendar tile being clicked. We can use this information to eg. stop calendar view from being updated if a tile is clicked (as user requested in, for example, #378).