### PR TITLE
Fix parcel version to 1.12.3, correct html meta link

### DIFF
--- a/sample/parcel-ts/index.html
+++ b/sample/parcel-ts/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="react-container"></div>
-    <script src="index.jsx"></script>
+    <script src="index.tsx"></script>
   </body>
 </html>

--- a/sample/parcel-ts/package.json
+++ b/sample/parcel-ts/package.json
@@ -19,9 +19,14 @@
     "react-dom": "^16.8.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0-0",
+    "@babel/plugin-proposal-class-properties": "^7.10.1",
+    "@babel/preset-env": "^7.10.1",
+    "@babel/preset-react": "^7.10.1",
     "@types/react": "^16.8.22",
     "@types/react-dom": "^16.8.4",
-    "parcel-bundler": "^1.12.4",
+    "less": "^3.11.1",
+    "parcel-bundler": "1.12.3",
     "tslint": "^5.18.0",
     "tslint-config-airbnb": "^5.11.1",
     "typescript": "^3.5.2"


### PR DESCRIPTION
Related to #380 I was testing out the ts sample which has two issues.
A small typo in the index.html file and the parcel version which picked 1.12.4 automatically and it has this issue:

```
react-calendar/sample/parcel-ts/index.tsx: Duplicate plugin/preset detected.
If you'd like to use two separate instances of a plugin,
they need separate names, e.g.

  plugins: [
    ['some-plugin', {}],
    ['some-plugin', {}, 'some unique name'],
  ]

Duplicates detected are:
[
  {
    "alias": "/Users/giacomocerquone/Documents/RepoPersonal/react-calendar/sample/parcel-ts/node_modules/@babel/plugin-proposal-class-properties/lib/index.js",
    "dirname": "/Users/giacomocerquone/Documents/RepoPersonal/react-calendar/sample/parcel-ts",
    "ownPass": false,
    "file": {
      "request": "@babel/proposal-class-properties",
      "resolved": "/Users/giacomocerquone/Documents/RepoPersonal/react-calendar/sample/parcel-ts/node_modules/@babel/plugin-proposal-class-properties/lib/index.js"
    }
  },
  {
    "alias": "base$2",
    "options": {
      "spec": false,
      "loose": false,
      "useBuiltIns": true
    },
    "dirname": "/Users/giacomocerquone/Documents/RepoPersonal/react-calendar/sample/parcel-ts",
    "ownPass": false
  }
]
```

which refers to this: https://github.com/parcel-bundler/parcel/issues/3049 and this: https://github.com/parcel-bundler/parcel/issues/1762

Now, considering it's "just" a bundler, I think it's perfectly fine to lock the version to the previous 1.12.3