### PR TITLE
Allow side effect for css files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/umd/index.js",
   "module": "dist/esm/index.js",
   "source": "src/index.js",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "scripts": {
     "build": "yarn build-js-all && yarn copy-styles && yarn build-styles",
     "build-js-all": "yarn build-js-esm && yarn build-js-umd",


### PR DESCRIPTION
If use `"sideEffects": false`, webpack in production mode doesn't import css files. I found fix from webpack maintainer https://github.com/webpack/webpack/issues/8814#issuecomment-465223178 