### PR TITLE
fix typo on Navigation Spec

### DIFF
--- a/src/Calendar/Navigation.spec.jsx
+++ b/src/Calendar/Navigation.spec.jsx
@@ -494,7 +494,7 @@ describe('Navigation', () => {
       locale,
       date,
       view,
-      label: 'Januar 2017',
+      label: 'January 2017',
     });
     expect(drillUp.text()).toBe(label);
   });


### PR DESCRIPTION
There is an typo in Navigation.spec.jsx that makes the test fail. So i correct the typo and then the test passed
Before:
![image](https://user-images.githubusercontent.com/7591715/86996360-a9409c00-c1d5-11ea-9b46-e87b325286aa.png)
![image](https://user-images.githubusercontent.com/7591715/86996382-b9587b80-c1d5-11ea-895d-3b862728d5e0.png)

After:
![image](https://user-images.githubusercontent.com/7591715/86996389-be1d2f80-c1d5-11ea-8824-9a2e559a8ef4.png)

