### PR TITLE
Update `sideEffects` property for webpack 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/umd/index.js",
   "module": "dist/esm/index.js",
   "source": "src/index.js",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "scripts": {
     "build": "yarn build-js-all && yarn copy-styles && yarn build-styles",
     "build-js-all": "yarn build-js-esm && yarn build-js-umd",


### PR DESCRIPTION
`Calendar.css` is not bundled in production mode because `sideEffects` is false.
https://stackoverflow.com/questions/49160752/what-does-webpack-4-expect-from-a-package-with-sideeffects-false