### PR TITLE
Implement WAI ARIA recommended focus handling

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -7,6 +7,7 @@ import CenturyView from './CenturyView';
 import DecadeView from './DecadeView';
 import YearView from './YearView';
 import MonthView from './MonthView';
+import FocusContainer from './FocusContainer';
 
 import { getBegin, getBeginNext, getEnd, getValueRange } from './shared/dates';
 import {
@@ -457,7 +458,7 @@ export default class Calendar extends Component {
     this.setState({ hover: null });
   };
 
-  renderContent(next) {
+  renderContent(activeTabDate, next) {
     const { activeStartDate: currentActiveStartDate, onMouseOver, valueType, value, view } = this;
     const {
       calendarType,
@@ -479,6 +480,7 @@ export default class Calendar extends Component {
 
     const commonProps = {
       activeStartDate,
+      activeTabDate,
       hover,
       locale,
       maxDate,
@@ -607,7 +609,7 @@ export default class Calendar extends Component {
 
   render() {
     const { className, inputRef, selectRange, showDoubleView } = this.props;
-    const { onMouseLeave, value } = this;
+    const { onMouseLeave, value, view, activeStartDate, setActiveStartDate } = this;
     const valueArray = [].concat(value);
 
     return (
@@ -621,14 +623,25 @@ export default class Calendar extends Component {
         ref={inputRef}
       >
         {this.renderNavigation()}
-        <div
-          className={`${baseClassName}__viewContainer`}
-          onBlur={selectRange ? onMouseLeave : null}
-          onMouseLeave={selectRange ? onMouseLeave : null}
+        <FocusContainer
+          activeStartDate={activeStartDate}
+          setActiveStartDate={setActiveStartDate}
+          showDoubleView={showDoubleView}
+          value={value}
+          view={view}
         >
-          {this.renderContent()}
-          {showDoubleView && this.renderContent(true)}
-        </div>
+          {({ activeTabDate, containerRef }) => (
+            <div
+              className={`${baseClassName}__viewContainer`}
+              onBlur={selectRange ? onMouseLeave : null}
+              onMouseLeave={selectRange ? onMouseLeave : null}
+              ref={containerRef}
+            >
+              {this.renderContent(activeTabDate)}
+              {showDoubleView && this.renderContent(activeTabDate, true)}
+            </div>
+          )}
+        </FocusContainer>
       </div>
     );
   }

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { getUserLocale } from 'get-user-locale';
 
@@ -76,6 +76,14 @@ export default function Navigation({
   const next2ButtonDisabled =
     shouldShowPrevNext2Buttons && maxDate && maxDate < nextActiveStartDate2;
 
+  // Make sure the navigation is not navigable at the first render
+  // so that the calendar takes the initial focus.
+  const [tabIndex, setTabIndex] = useState(-1);
+  useEffect(() => {
+    setTabIndex(-1);
+    setTimeout(() => setTabIndex(0), 0);
+  }, [view]);
+
   function onClickPrevious() {
     setActiveStartDate(previousActiveStartDate, 'prev');
   }
@@ -128,6 +136,7 @@ export default function Navigation({
         disabled={!drillUpAvailable}
         onClick={drillUp}
         style={{ flexGrow: 1 }}
+        tabIndex={tabIndex}
         type="button"
       >
         <span className={`${labelClassName}__labelText ${labelClassName}__labelText--from`}>
@@ -153,6 +162,7 @@ export default function Navigation({
           className={`${className}__arrow ${className}__prev2-button`}
           disabled={prev2ButtonDisabled}
           onClick={onClickPrevious2}
+          tabIndex={tabIndex}
           type="button"
         >
           {prev2Label}
@@ -164,6 +174,7 @@ export default function Navigation({
           className={`${className}__arrow ${className}__prev-button`}
           disabled={prevButtonDisabled}
           onClick={onClickPrevious}
+          tabIndex={tabIndex}
           type="button"
         >
           {prevLabel}
@@ -176,6 +187,7 @@ export default function Navigation({
           className={`${className}__arrow ${className}__next-button`}
           disabled={nextButtonDisabled}
           onClick={onClickNext}
+          tabIndex={tabIndex}
           type="button"
         >
           {nextLabel}
@@ -187,6 +199,7 @@ export default function Navigation({
           className={`${className}__arrow ${className}__next2-button`}
           disabled={next2ButtonDisabled}
           onClick={onClickNext2}
+          tabIndex={tabIndex}
           type="button"
         >
           {next2Label}

--- a/src/CenturyView/Decade.jsx
+++ b/src/CenturyView/Decade.jsx
@@ -10,13 +10,19 @@ import { tileProps } from '../shared/propTypes';
 
 const className = 'react-calendar__century-view__decades__decade';
 
-export default function Decade({ classes, formatYear = defaultFormatYear, ...otherProps }) {
+export default function Decade({
+  activeTabDate,
+  classes,
+  formatYear = defaultFormatYear,
+  ...otherProps
+}) {
   const { date, locale } = otherProps;
 
   return (
     <Tile
       {...otherProps}
       classes={[].concat(classes, className)}
+      isFocusable={activeTabDate <= getDecadeEnd(date) && activeTabDate > getDecadeStart(date)}
       maxDateTransform={getDecadeEnd}
       minDateTransform={getDecadeStart}
       view="century"

--- a/src/DecadeView/Year.jsx
+++ b/src/DecadeView/Year.jsx
@@ -9,13 +9,19 @@ import { tileProps } from '../shared/propTypes';
 
 const className = 'react-calendar__decade-view__years__year';
 
-export default function Year({ classes, formatYear = defaultFormatYear, ...otherProps }) {
+export default function Year({
+  activeTabDate,
+  classes,
+  formatYear = defaultFormatYear,
+  ...otherProps
+}) {
   const { date, locale } = otherProps;
 
   return (
     <Tile
       {...otherProps}
       classes={[].concat(classes, className)}
+      isFocusable={activeTabDate.getFullYear() === date.getFullYear()}
       maxDateTransform={getYearEnd}
       minDateTransform={getYearStart}
       view="decade"

--- a/src/FocusContainer.jsx
+++ b/src/FocusContainer.jsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { getBeginNext, getBeginPrevious, getEndPrevious } from './shared/dates';
+import { isValue, isView } from './shared/propTypes';
+
+export default function FocusContainer({
+  children,
+  value,
+  activeStartDate,
+  setActiveStartDate,
+  showDoubleView,
+  view,
+}) {
+  const currentValue = Array.isArray(value) ? value[0] : value;
+  const [activeTabDate, setActiveTabDate] = useState(currentValue ?? activeStartDate);
+  const containerRef = useRef(null);
+
+  // Move the focus to the current focusable element
+  useEffect(() => {
+    // If the previously focused element was not in the grid,
+    // (e.g. it was a navigation button), we don't move the focus
+    if (!containerRef.current?.contains(document.activeElement)) {
+      return;
+    }
+
+    // We are applying the focus async, to ensure that the calendar view
+    // was already updated
+    setTimeout(() => {
+      const focusableElement = containerRef.current?.querySelector('[tabindex="0"]');
+      if (focusableElement) {
+        focusableElement.focus();
+      }
+    }, 0);
+  }, [activeTabDate]);
+
+  // Set the focusable element to the active start date when the
+  // active start date changes and the previous focusable element goes
+  // out of view (e.g. when using the navigation buttons)
+  useEffect(() => {
+    const beginNext = getBeginNext(view, activeStartDate);
+    const endPrevious = getEndPrevious(view, activeStartDate);
+
+    if (
+      activeTabDate <= endPrevious ||
+      (!showDoubleView && activeTabDate >= beginNext) ||
+      (showDoubleView && activeTabDate >= getBeginNext(view, beginNext))
+    ) {
+      setActiveTabDate(activeStartDate);
+    }
+  }, [view, activeStartDate]);
+
+  // Handle arrow keyboard interactions by moving the focusable element around
+  useEffect(() => {
+    const handleKeyPress = (event) => {
+      // Only handle keyboard events when we're focused within the calendar grid
+      if (!containerRef.current?.contains(document.activeElement)) {
+        return;
+      }
+
+      const nextTabDate = new Date(activeTabDate);
+
+      switch (true) {
+        case event.key === 'ArrowUp' && view === 'month':
+          nextTabDate.setDate(activeTabDate.getDate() - 7);
+          break;
+        case event.key === 'ArrowUp' && view === 'year':
+          nextTabDate.setMonth(activeTabDate.getMonth() - 3);
+          break;
+        case event.key === 'ArrowUp' && view === 'decade':
+          nextTabDate.setFullYear(activeTabDate.getFullYear() - 3);
+          break;
+        case event.key === 'ArrowUp' && view === 'century':
+          nextTabDate.setFullYear(activeTabDate.getFullYear() - 30);
+          break;
+        case event.key === 'ArrowDown' && view === 'month':
+          nextTabDate.setDate(activeTabDate.getDate() + 7);
+          break;
+        case event.key === 'ArrowDown' && view === 'year':
+          nextTabDate.setMonth(activeTabDate.getMonth() + 3);
+          break;
+        case event.key === 'ArrowDown' && view === 'decade':
+          nextTabDate.setFullYear(activeTabDate.getFullYear() + 3);
+          break;
+        case event.key === 'ArrowDown' && view === 'century':
+          nextTabDate.setFullYear(activeTabDate.getFullYear() + 30);
+          break;
+        case event.key === 'ArrowLeft' && view === 'month':
+          nextTabDate.setDate(activeTabDate.getDate() - 1);
+          break;
+        case event.key === 'ArrowLeft' && view === 'year':
+          nextTabDate.setMonth(activeTabDate.getMonth() - 1);
+          break;
+        case event.key === 'ArrowLeft' && view === 'decade':
+          nextTabDate.setFullYear(activeTabDate.getFullYear() - 1);
+          break;
+        case event.key === 'ArrowLeft' && view === 'century':
+          nextTabDate.setFullYear(activeTabDate.getFullYear() - 10);
+          break;
+        case event.key === 'ArrowRight' && view === 'month':
+          nextTabDate.setDate(activeTabDate.getDate() + 1);
+          break;
+        case event.key === 'ArrowRight' && view === 'year':
+          nextTabDate.setMonth(activeTabDate.getMonth() + 1);
+          break;
+        case event.key === 'ArrowRight' && view === 'decade':
+          nextTabDate.setFullYear(activeTabDate.getFullYear() + 1);
+          break;
+        case event.key === 'ArrowRight' && view === 'century':
+          nextTabDate.setFullYear(activeTabDate.getFullYear() + 10);
+          break;
+        default:
+          break;
+      }
+
+      // If the focusable element is unchanged, exit
+      if (nextTabDate.getTime() === activeTabDate.getTime()) {
+        return;
+      }
+
+      setActiveTabDate(nextTabDate);
+
+      // If the new focusable element is out of view, adjust the view
+      // by changing the active start date
+      const beginNext = getBeginNext(view, activeStartDate);
+      if (nextTabDate < activeStartDate) {
+        setActiveStartDate(getBeginPrevious(view, activeStartDate));
+      } else if (
+        (!showDoubleView && nextTabDate >= beginNext) ||
+        (showDoubleView && nextTabDate >= getBeginNext(view, beginNext))
+      ) {
+        setActiveStartDate(beginNext);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyPress);
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress);
+    };
+  });
+
+  return <>{children({ activeTabDate, containerRef })}</>;
+}
+
+FocusContainer.propTypes = {
+  activeStartDate: PropTypes.instanceOf(Date).isRequired,
+  children: PropTypes.func.isRequired,
+  setActiveStartDate: PropTypes.func.isRequired,
+  showDoubleView: PropTypes.bool,
+  value: PropTypes.oneOfType([PropTypes.string, isValue]),
+  view: isView.isRequired,
+};

--- a/src/MonthView/Day.jsx
+++ b/src/MonthView/Day.jsx
@@ -14,6 +14,7 @@ import { tileProps } from '../shared/propTypes';
 const className = 'react-calendar__month-view__days__day';
 
 export default function Day({
+  activeTabDate,
   formatDay = defaultFormatDay,
   formatLongDate = defaultFormatLongDate,
   calendarType,
@@ -33,6 +34,9 @@ export default function Day({
         date.getMonth() !== currentMonthIndex ? `${className}--neighboringMonth` : null,
       )}
       formatAbbr={formatLongDate}
+      isFocusable={
+        activeTabDate.getTime() === date.getTime() && date.getMonth() === currentMonthIndex
+      }
       maxDateTransform={getDayEnd}
       minDateTransform={getDayStart}
       view="month"

--- a/src/Tile.jsx
+++ b/src/Tile.jsx
@@ -61,6 +61,7 @@ export default class Tile extends Component {
       minDateTransform,
       onClick,
       onMouseOver,
+      isFocusable,
       style,
       tileDisabled,
       view,
@@ -79,6 +80,7 @@ export default class Tile extends Component {
         onFocus={onMouseOver && (() => onMouseOver(date))}
         onMouseOver={onMouseOver && (() => onMouseOver(date))}
         style={style}
+        tabIndex={isFocusable ? 0 : -1}
         type="button"
       >
         {formatAbbr ? <abbr aria-label={formatAbbr(locale, date)}>{children}</abbr> : children}

--- a/src/YearView/Month.jsx
+++ b/src/YearView/Month.jsx
@@ -13,6 +13,7 @@ import { tileProps } from '../shared/propTypes';
 const className = 'react-calendar__year-view__months__month';
 
 export default function Month({
+  activeTabDate,
   classes,
   formatMonth = defaultFormatMonth,
   formatMonthYear = defaultFormatMonthYear,
@@ -25,6 +26,10 @@ export default function Month({
       {...otherProps}
       classes={[].concat(classes, className)}
       formatAbbr={formatMonthYear}
+      isFocusable={
+        activeTabDate.getMonth() === date.getMonth() &&
+        activeTabDate.getFullYear() === date.getFullYear()
+      }
       maxDateTransform={getMonthEnd}
       minDateTransform={getMonthStart}
       view="year"

--- a/src/shared/propTypes.js
+++ b/src/shared/propTypes.js
@@ -106,6 +106,7 @@ isView.isRequired = (props, propName, componentName) => {
 
 export const tileGroupProps = {
   activeStartDate: PropTypes.instanceOf(Date).isRequired,
+  activeTabDate: PropTypes.instanceOf(Date).isRequired,
   hover: PropTypes.instanceOf(Date),
   locale: PropTypes.string,
   maxDate: isMaxDate,
@@ -122,6 +123,7 @@ export const tileProps = {
   activeStartDate: PropTypes.instanceOf(Date).isRequired,
   classes: PropTypes.arrayOf(PropTypes.string).isRequired,
   date: PropTypes.instanceOf(Date).isRequired,
+  isFocusable: PropTypes.bool,
   locale: PropTypes.string,
   maxDate: isMaxDate,
   minDate: isMinDate,


### PR DESCRIPTION
Fixes #354 

Introduces the concept of an active focusable element, to adjust the keyboard interaction to match [WAI-ARIA recommendations](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/datepicker-dialog.html). 

![Kapture 2020-10-26 at 21 36 55](https://user-images.githubusercontent.com/4643658/97228586-6e3f9400-17d7-11eb-986b-e1e9d9d89c90.gif)

@wojtekmaj Would love your help in pushing this out. Things I don't handle yet (that I know of):

- [ ] Min/max dates (should be easy)
- [ ] Disabled dates - that one will be tricky. I guess ideally we would jump to the next non-disabled date, but not sure how we can implement that in a sane way