### PR TITLE
Render TileGroup using css grid, fixes #222

### DIFF
--- a/src/Calendar.less
+++ b/src/Calendar.less
@@ -83,6 +83,9 @@
     }
 
     &__days {
+      display: grid;
+      grid-template-columns: repeat(7, 1fr);
+
       &__day {
         &--weekend {
           color: rgb(209, 0, 0);
@@ -101,6 +104,13 @@
     .react-calendar__tile {
       padding: 2em .5em;
     }
+  }
+
+  &__year-view__months,
+  &__decade-view__years,
+  &__century-view__decades {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
   }
 
   &__tile {

--- a/src/MonthView/Days.jsx
+++ b/src/MonthView/Days.jsx
@@ -66,7 +66,6 @@ export default function Days(props) {
     <TileGroup
       {...otherProps}
       className="react-calendar__month-view__days"
-      count={7}
       currentMonthIndex={monthIndex}
       dateTransform={(day) => {
         const date = new Date();

--- a/src/TileGroup.jsx
+++ b/src/TileGroup.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Flex from './Flex';
-
 import { getTileClasses } from './shared/utils';
 import { tileGroupProps } from './shared/propTypes';
 
 export default function TileGroup({
   className,
-  count = 3,
   dateTransform,
   dateType,
   end,
@@ -22,8 +19,9 @@ export default function TileGroup({
   ...tileProps
 }) {
   const tiles = [];
-  for (let point = start; point <= end; point += step) {
+  for (let point = start, i = 0; point <= end; point += step, i++) {
     const date = dateTransform(point);
+    const style = i === 0 && offset ? { gridColumn: offset + 1 } : null;
 
     tiles.push(
       <Tile
@@ -33,27 +31,24 @@ export default function TileGroup({
         })}
         date={date}
         point={point}
+        style={style}
         {...tileProps}
       />,
     );
   }
 
   return (
-    <Flex
+    <div
       className={className}
-      count={count}
-      offset={offset}
-      wrap
     >
       {tiles}
-    </Flex>
+    </div>
   );
 }
 
 TileGroup.propTypes = {
   ...tileGroupProps,
   activeStartDate: PropTypes.instanceOf(Date),
-  count: PropTypes.number,
   dateTransform: PropTypes.func.isRequired,
   offset: PropTypes.number,
   step: PropTypes.number,

--- a/src/TileGroup.spec.jsx
+++ b/src/TileGroup.spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import TileGroup from './TileGroup';
+
+describe('<TileGroup /> component', () => {
+  const defaultProps = {
+    start: -5,
+    end: 36,
+    value: new Date(),
+    valueType: 'day',
+    date: new Date(),
+    dateType: 'day',
+    hover: null,
+    tile: () => null,
+    dateTransform: () => new Date(),
+  };
+
+  it('add style of offset if given', () => {
+    const offset = 2;
+    const component = shallow(
+      <TileGroup {...defaultProps} offset={offset} />,
+    );
+    const tiles = component.find('div').prop('children');
+
+    expect(tiles[0].props).toHaveProperty('style', { gridColumn: offset + 1 });
+  });
+});


### PR DESCRIPTION
This PR implements the tile group positioning using `css grid` as described in https://zellwk.com/blog/calendar-with-css-grid/

![0nx0OArpNb](https://user-images.githubusercontent.com/9304194/98688335-6a814500-2373-11eb-974f-9e51d50f6639.gif)
