### PR TITLE
Remove extra space for 'month-view'

### DIFF
--- a/src/MonthView.jsx
+++ b/src/MonthView.jsx
@@ -74,7 +74,7 @@ export default function MonthView(props) {
       className={[
         className,
         showWeekNumbers ? `${className}--weekNumbers` : '',
-      ].join(' ')}
+      ].filter(Boolean).join(' ')}
     >
       <div
         style={{


### PR DESCRIPTION
Remove extra space for 'react-calendar__month-view' `classname` when no `showWeekNumbers`.