### PR TITLE
Feat: Pass any Props Down to Navigation Button

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -568,6 +568,7 @@ export default class Calendar extends Component {
       minDate,
       navigationAriaLabel,
       navigationLabel,
+      navigationButtonProps,
       next2AriaLabel,
       next2Label,
       nextAriaLabel,
@@ -590,6 +591,7 @@ export default class Calendar extends Component {
         minDate={minDate}
         navigationAriaLabel={navigationAriaLabel}
         navigationLabel={navigationLabel}
+        navigationButtonProps={navigationButtonProps}
         next2AriaLabel={next2AriaLabel}
         next2Label={next2Label}
         nextAriaLabel={nextAriaLabel}
@@ -677,6 +679,7 @@ Calendar.propTypes = {
   minDetail: PropTypes.oneOf(allViews),
   navigationAriaLabel: PropTypes.string,
   navigationLabel: PropTypes.func,
+  navigationButtonProps: PropTypes.object,
   next2AriaLabel: PropTypes.string,
   next2Label: PropTypes.node,
   nextAriaLabel: PropTypes.string,

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -30,6 +30,7 @@ export default function Navigation({
   minDate,
   navigationAriaLabel = '',
   navigationLabel,
+  navigationButtonProps = {},
   next2AriaLabel = '',
   next2Label = '»',
   nextAriaLabel = '',
@@ -132,6 +133,7 @@ export default function Navigation({
         onClick={drillUp}
         style={{ flexGrow: 1 }}
         type="button"
+        {...navigationButtonProps}
       >
         <span className={`${labelClassName}__labelText ${labelClassName}__labelText--from`}>
           {renderLabel(activeStartDate)}

--- a/src/Calendar/Navigation.jsx
+++ b/src/Calendar/Navigation.jsx
@@ -127,13 +127,13 @@ export default function Navigation({
     const labelClassName = `${className}__label`;
     return (
       <button
+        {...navigationButtonProps}
         aria-label={navigationAriaLabel}
         className={labelClassName}
         disabled={!drillUpAvailable}
         onClick={drillUp}
         style={{ flexGrow: 1 }}
         type="button"
-        {...navigationButtonProps}
       >
         <span className={`${labelClassName}__labelText ${labelClassName}__labelText--from`}>
           {renderLabel(activeStartDate)}

--- a/src/Calendar/Navigation.spec.jsx
+++ b/src/Calendar/Navigation.spec.jsx
@@ -560,17 +560,35 @@ describe('Navigation', () => {
     });
   });
 
-  it('renders custom navigation button props when given navigationButtonProps prop', () => {
-    const navigationButtonProps = { tabIndex: "-1" };
+  describe('when given navigationButtonProps prop', () => {
+    it('renders custom navigation button props', () => {
+      const navigationButtonProps = { tabIndex: "-1", 'data-test-id': "navigation-button" };
+  
+      const component = shallow(
+        <Navigation
+          {...defaultProps}
+          navigationButtonProps={navigationButtonProps}
+        />,
+      );
+  
+      const drillUp = component.find('.react-calendar__navigation__label');
+      expect(drillUp.prop('tabIndex')).toBe("-1");
+      expect(drillUp.prop('data-test-id')).toBe("navigation-button");
+    });
 
-    const component = shallow(
-      <Navigation
-        {...defaultProps}
-        navigationButtonProps={navigationButtonProps}
-      />,
-    );
-
-    const drillUp = component.find('.react-calendar__navigation__label');
-    expect(drillUp.prop('tabIndex')).toBe("-1");
+    it('renders doesn\'t overwrite other props', () => {
+      const navigationButtonProps = { className: 'custom-class-name' };
+  
+      const component = shallow(
+        <Navigation
+          {...defaultProps}
+          navigationButtonProps={navigationButtonProps}
+        />,
+      );
+  
+      const drillUp = component.find('.react-calendar__navigation__label');
+      expect(drillUp.exists()).toBeTruthy();
+      expect(drillUp.prop('className')).not.toBe("custom-class-name");
+    });
   });
 });

--- a/src/Calendar/Navigation.spec.jsx
+++ b/src/Calendar/Navigation.spec.jsx
@@ -559,4 +559,18 @@ describe('Navigation', () => {
       expect(navigationLabel.text()).toBe('Year – Year');
     });
   });
+
+  it('renders custom navigation button props when given navigationButtonProps prop', () => {
+    const navigationButtonProps = { tabIndex: "-1" };
+
+    const component = shallow(
+      <Navigation
+        {...defaultProps}
+        navigationButtonProps={navigationButtonProps}
+      />,
+    );
+
+    const drillUp = component.find('.react-calendar__navigation__label');
+    expect(drillUp.prop('tabIndex')).toBe("-1");
+  });
 });


### PR DESCRIPTION
# Summary

In our use case, we didn't want to have a clickable navigation label. This was easy to achieve via `pointer-events: none` but still a user can `tab` to this element and focus it. In a case like this, it's helpful to enable passing props through to the actual DOM element. This would also allow the developer to pass custom event listeners like `onFocus` or `onMouseEnter`.

# Example usage

```
return (
    <Calendar navigationButtonProps={{ tabIndex: '-1' }} />
);
```