### PR TITLE
Add react-calendar__month-view__weekdays__weekday--current class to current day of the week

### DIFF
--- a/src/MonthView/Weekdays.jsx
+++ b/src/MonthView/Weekdays.jsx
@@ -45,8 +45,8 @@ export default function Weekdays(props) {
         key={weekday}
         className={clsx(
           weekdayClassName,
+          isCurrentDayOfWeek(weekdayDate) && `${weekdayClassName}--current`,
           isWeekend(weekdayDate, calendarType) && `${weekdayClassName}--weekend`,
-          isCurrentDayOfWeek(weekdayDate) && `${weekdayClassName}--currentDayOfWeek`,
         )}
       >
         <abbr aria-label={abbr} title={abbr}>

--- a/src/MonthView/Weekdays.jsx
+++ b/src/MonthView/Weekdays.jsx
@@ -5,7 +5,7 @@ import { getYear, getMonth, getMonthStart } from '@wojtekmaj/date-utils';
 
 import Flex from '../Flex';
 
-import { getDayOfWeek, isWeekend } from '../shared/dates';
+import { getDayOfWeek, isCurrentDayOfWeek, isWeekend } from '../shared/dates';
 import {
   formatShortWeekday as defaultFormatShortWeekday,
   formatWeekday as defaultFormatWeekday,
@@ -46,6 +46,7 @@ export default function Weekdays(props) {
         className={clsx(
           weekdayClassName,
           isWeekend(weekdayDate, calendarType) && `${weekdayClassName}--weekend`,
+          isCurrentDayOfWeek(weekdayDate) && `${weekdayClassName}--currentDayOfWeek`,
         )}
       >
         <abbr aria-label={abbr} title={abbr}>

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -310,7 +310,16 @@ export function getDecadeLabel(locale, formatYear, date) {
 }
 
 /**
- * Returns a boolean determining whether a given date is on Saturday or Sunday.
+ * Returns a boolean determining whether a given date is the current day of the week.
+ *
+ * @param {Date} date Date.
+ */
+export function isCurrentDayOfWeek(date) {
+  return date.getDay() === new Date().getDay();
+}
+
+/**
+ * Returns a boolean determining whether a given date is a weekend day.
  *
  * @param {Date} date Date.
  */
@@ -327,14 +336,3 @@ export function isWeekend(date, calendarType = CALENDAR_TYPES.ISO_8601) {
       throw new Error('Unsupported calendar type.');
   }
 }
-
-/**
- * Returns a boolean determining whether a given date is current day of the week.
- *
- * @param {Date} date Date.
- */
-export const isCurrentDayOfWeek = (date) => {
-  const today = new Date(Date.now()).getDay();
-  const weekday = date.getDay();
-  return weekday === today;
-};

--- a/src/shared/dates.js
+++ b/src/shared/dates.js
@@ -327,3 +327,14 @@ export function isWeekend(date, calendarType = CALENDAR_TYPES.ISO_8601) {
       throw new Error('Unsupported calendar type.');
   }
 }
+
+/**
+ * Returns a boolean determining whether a given date is current day of the week.
+ *
+ * @param {Date} date Date.
+ */
+export const isCurrentDayOfWeek = (date) => {
+  const today = new Date(Date.now()).getDay();
+  const weekday = date.getDay();
+  return weekday === today;
+};

--- a/test/Test.less
+++ b/test/Test.less
@@ -149,6 +149,17 @@ body {
             }
           }
         }
+
+        &__month-view {
+          &__weekdays {
+            &__weekday {
+              &--current {
+                @bgcolor: lighten(rgb(220, 220, 0), 30%);
+                background: @bgcolor;
+              }
+            }
+          }
+        }
       }
 
       & > p {


### PR DESCRIPTION
Adds a CSS class for the weekday if it is the current day of the week.

Closes #676