### PR TITLE
Expose the default props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ import CenturyView from './CenturyView';
 import DecadeView from './DecadeView';
 import YearView from './YearView';
 import MonthView from './MonthView';
+import * as Shared from './shared';
 
 export default Calendar;
 
-export { Calendar, Navigation, CenturyView, DecadeView, YearView, MonthView };
+export { Calendar, Navigation, CenturyView, DecadeView, YearView, MonthView, Shared };

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,0 +1,4 @@
+export * as Const from './const';
+export * as DateFormatter from './dateFormatter';
+export * as Dates from './dates';
+export * as Utils from './utils';


### PR DESCRIPTION
https://github.com/wojtekmaj/react-calendar/issues/706

I've exposed shared folder which contains default definitions of `format*`. Unfortunately, I wasn't able to find default implementation for `navigationLabel` function.