### PR TITLE
Fix and test turning goToRangeStartOnSelect off

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,5 @@
     "url": "https://github.com/wojtekmaj/react-calendar.git"
   },
   "funding": "https://github.com/wojtekmaj/react-calendar?sponsor=1",
-  "packageManager": "yarn@3.1.0"
+  "packageManager": "yarn@3.5.1"
 }

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 5
+  version: 6
   cacheKey: 8
 
 "@ampproject/remapping@npm:^2.2.0":
@@ -1025,7 +1025,7 @@ __metadata:
 
 "fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
     node-gyp: latest
   conditions: os=darwin
@@ -1719,7 +1719,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -1941,11 +1941,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.0#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=ddd1e8"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
+  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
   languageName: node
   linkType: hard
 

--- a/src/Calendar.spec.tsx
+++ b/src/Calendar.spec.tsx
@@ -707,6 +707,85 @@ describe('Calendar', () => {
 
       expect(onActiveStartDateChange).not.toHaveBeenCalled();
     });
+
+    it('returns to start of range when range is completed', () => {
+      const onActiveStartDateChange = vi.fn();
+
+      const initialRange = new Date(2017, 0, 10);
+
+      const { container } = render(
+        <Calendar
+          view="month"
+          selectRange
+          onActiveStartDateChange={onActiveStartDateChange}
+          defaultValue={initialRange}
+        />,
+      );
+
+      const nextMonthButton = container.querySelector(
+        'button.react-calendar__navigation__next-button',
+      ) as HTMLButtonElement;
+
+      act(() => {
+        nextMonthButton.click();
+      });
+      // Disregard the call on the above button click
+      onActiveStartDateChange.mockClear();
+
+      // First day not in the previous month
+      const firstDayTile = container.querySelector(
+        '.react-calendar__tile:not([react-calendar__month-view__days__day--weekend])',
+      ) as HTMLButtonElement;
+
+      act(() => {
+        firstDayTile.click();
+      });
+
+      expect(onActiveStartDateChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'onChange',
+          activeStartDate: new Date(2017, 0, 1),
+          view: 'month',
+        }),
+      );
+    });
+
+    it('does not change activeStartDate on range completion when goToRangeStartOnSelect is set to false', () => {
+      const onActiveStartDateChange = vi.fn();
+
+      const initialRange = new Date(2017, 0, 10);
+
+      const { container } = render(
+        <Calendar
+          view="month"
+          selectRange
+          onActiveStartDateChange={onActiveStartDateChange}
+          defaultValue={initialRange}
+          goToRangeStartOnSelect={false}
+        />,
+      );
+
+      const nextMonthButton = container.querySelector(
+        'button.react-calendar__navigation__next-button',
+      ) as HTMLButtonElement;
+
+      act(() => {
+        nextMonthButton.click();
+      });
+      // Disregard the call on the above button click
+      onActiveStartDateChange.mockClear();
+
+      // First day not in the previous month
+      const firstDayTile = container.querySelector(
+        '.react-calendar__tile:not([react-calendar__month-view__days__day--weekend])',
+      ) as HTMLButtonElement;
+
+      act(() => {
+        firstDayTile.click();
+      });
+
+      expect(onActiveStartDateChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('handles view change properly', () => {

--- a/src/Calendar.tsx
+++ b/src/Calendar.tsx
@@ -691,7 +691,7 @@ export default class Calendar extends Component<CalendarProps, CalendarState> {
             ...(this.props as CalendarPropsWithDefaults),
             value: nextValue,
           })
-        : null;
+        : this.activeStartDate;
 
     event.persist();
 

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 5
+  version: 6
   cacheKey: 8
 
 "@ampproject/remapping@npm:^2.2.0":
@@ -1025,7 +1025,7 @@ __metadata:
 
 "fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
     node-gyp: latest
   conditions: os=darwin
@@ -1720,7 +1720,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -1942,11 +1942,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.0#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=ddd1e8"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
+  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 5
+  version: 6
   cacheKey: 8
 
 "@adobe/css-tools@npm:^4.0.1":
@@ -2229,7 +2229,7 @@ __metadata:
 
 "fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
     node-gyp: latest
   conditions: os=darwin
@@ -4101,7 +4101,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -4114,7 +4114,7 @@ __metadata:
 
 "resolve@patch:resolve@^2.0.0-next.4#~builtin<compat/resolve>":
   version: 2.0.0-next.4
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.4#~builtin<compat/resolve>::version=2.0.0-next.4&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.4#~builtin<compat/resolve>::version=2.0.0-next.4&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -4694,11 +4694,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.0#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=ddd1e8"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6a1fe9a77bb9c5176ead919cc4a1499ee63e46b4e05bf667079f11bf3a8f7887f135aa72460a4c3b016e6e6bb65a822cb8689a6d86cbfe92d22cc9f501f09213
+  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixing the `goToRangeStartOnSelect` property so that, when off, the view is not changed once a range is complete should fix or at least provide an easier workaround to the following issues:

- [#339](https://github.com/wojtekmaj/react-calendar/issues/339)
- [#611](https://github.com/wojtekmaj/react-calendar/issues/611)
- [#367](https://github.com/wojtekmaj/react-calendar/issues/367)

without having to directly control `activeStartDate`.