### PR TITLE
Expose `OnArgs` type

### DIFF
--- a/packages/react-calendar/src/index.ts
+++ b/packages/react-calendar/src/index.ts
@@ -9,6 +9,7 @@ export type { CalendarProps } from './Calendar.js';
 
 export type {
   NavigationLabelFunc,
+  OnArgs,
   OnClickFunc,
   OnClickWeekNumberFunc,
   TileClassNameFunc,


### PR DESCRIPTION
Fixes https://github.com/wojtekmaj/react-calendar/issues/896