### PR TITLE
Fix calendarType not passed to Day component

### DIFF
--- a/packages/react-calendar/src/MonthView.tsx
+++ b/packages/react-calendar/src/MonthView.tsx
@@ -9,7 +9,7 @@ import WeekNumbers from './MonthView/WeekNumbers.js';
 import { CALENDAR_TYPES, CALENDAR_TYPE_LOCALES } from './shared/const.js';
 import { isCalendarType, tileGroupProps } from './shared/propTypes.js';
 
-import type { CalendarType } from './shared/types.js';
+import type { CalendarType, DeprecatedCalendarType } from './shared/types.js';
 
 function getCalendarTypeFromLocale(locale: string | undefined): CalendarType {
   if (locale) {
@@ -24,10 +24,14 @@ function getCalendarTypeFromLocale(locale: string | undefined): CalendarType {
 }
 
 type MonthViewProps = {
+  calendarType?: CalendarType | DeprecatedCalendarType;
   showWeekNumbers?: boolean;
-} & React.ComponentProps<typeof Weekdays> &
-  React.ComponentProps<typeof WeekNumbers> &
-  React.ComponentProps<typeof Days>;
+} & Omit<
+  React.ComponentProps<typeof Weekdays> &
+    React.ComponentProps<typeof WeekNumbers> &
+    React.ComponentProps<typeof Days>,
+  'calendarType'
+>;
 
 const MonthView: React.FC<MonthViewProps> = function MonthView(props) {
   const { activeStartDate, locale, onMouseLeave, showFixedNumberOfWeeks } = props;

--- a/packages/react-calendar/src/MonthView/Day.spec.tsx
+++ b/packages/react-calendar/src/MonthView/Day.spec.tsx
@@ -6,10 +6,11 @@ import Day from './Day.js';
 
 const tileProps = {
   activeStartDate: new Date(2018, 0, 1),
+  calendarType: 'iso8601',
   classes: ['react-calendar__tile'],
   currentMonthIndex: 0,
   date: new Date(2018, 0, 1),
-};
+} satisfies React.ComponentProps<typeof Day>;
 
 describe('Day', () => {
   it('applies given classNames properly', () => {

--- a/packages/react-calendar/src/MonthView/Day.tsx
+++ b/packages/react-calendar/src/MonthView/Day.tsx
@@ -15,7 +15,7 @@ import type { CalendarType, DeprecatedCalendarType } from '../shared/types.js';
 const className = 'react-calendar__month-view__days__day';
 
 type DayProps = {
-  calendarType?: CalendarType | DeprecatedCalendarType;
+  calendarType: CalendarType | DeprecatedCalendarType | undefined;
   classes?: string[];
   currentMonthIndex: number;
   formatDay?: typeof defaultFormatDay;

--- a/packages/react-calendar/src/MonthView/Days.tsx
+++ b/packages/react-calendar/src/MonthView/Days.tsx
@@ -11,7 +11,7 @@ import type { CalendarType, DeprecatedCalendarType } from '../shared/types.js';
 
 type DaysProps = {
   activeStartDate: Date;
-  calendarType?: CalendarType | DeprecatedCalendarType;
+  calendarType: CalendarType | DeprecatedCalendarType | undefined;
   showFixedNumberOfWeeks?: boolean;
   showNeighboringMonth?: boolean;
 } & Omit<
@@ -89,8 +89,8 @@ export default function Days(props: DaysProps) {
           key={date.getTime()}
           {...otherProps}
           {...otherTileProps}
-          calendarType={calendarType}
           activeStartDate={activeStartDate}
+          calendarType={calendarTypeOrDeprecatedCalendarType}
           currentMonthIndex={monthIndex}
           date={date}
         />

--- a/packages/react-calendar/src/MonthView/Days.tsx
+++ b/packages/react-calendar/src/MonthView/Days.tsx
@@ -89,6 +89,7 @@ export default function Days(props: DaysProps) {
           key={date.getTime()}
           {...otherProps}
           {...otherTileProps}
+          calendarType={calendarType}
           activeStartDate={activeStartDate}
           currentMonthIndex={monthIndex}
           date={date}

--- a/packages/react-calendar/src/MonthView/WeekNumbers.tsx
+++ b/packages/react-calendar/src/MonthView/WeekNumbers.tsx
@@ -15,7 +15,7 @@ import type {
 
 type WeekNumbersProps = {
   activeStartDate: Date;
-  calendarType?: CalendarType | DeprecatedCalendarType;
+  calendarType: CalendarType | DeprecatedCalendarType | undefined;
   onClickWeekNumber?: OnClickWeekNumberFunc;
   onMouseLeave?: () => void;
   showFixedNumberOfWeeks?: boolean;

--- a/packages/react-calendar/src/MonthView/Weekdays.tsx
+++ b/packages/react-calendar/src/MonthView/Weekdays.tsx
@@ -17,7 +17,7 @@ const className = 'react-calendar__month-view__weekdays';
 const weekdayClassName = `${className}__weekday`;
 
 type WeekdaysProps = {
-  calendarType?: CalendarType | DeprecatedCalendarType;
+  calendarType: CalendarType | DeprecatedCalendarType | undefined;
   formatShortWeekday?: typeof defaultFormatShortWeekday;
   formatWeekday?: typeof defaultFormatWeekday;
   locale?: string;

--- a/packages/react-calendar/src/shared/utils.ts
+++ b/packages/react-calendar/src/shared/utils.ts
@@ -164,7 +164,7 @@ const calendarTypeMap: Record<DeprecatedCalendarType, CalendarType> = {
 };
 
 function isDeprecatedCalendarType(
-  calendarType?: CalendarType | DeprecatedCalendarType,
+  calendarType: CalendarType | DeprecatedCalendarType | undefined,
 ): calendarType is DeprecatedCalendarType {
   return calendarType !== undefined && calendarType in DEPRECATED_CALENDAR_TYPES;
 }


### PR DESCRIPTION
This change makes weekend indicators work properly according to the calendar type