### PR TITLE
accessibility: Keep focus in calendar when changing views

### DIFF
--- a/packages/react-calendar/src/Calendar.spec.tsx
+++ b/packages/react-calendar/src/Calendar.spec.tsx
@@ -544,6 +544,9 @@ describe('Calendar', () => {
         '.react-calendar__navigation__label',
       ) as HTMLButtonElement;
 
+      expect(document.activeElement).toBe(
+        container.querySelector('.react-calendar__viewContainer'),
+      );
       expect(label).toHaveAccessibleName('2011 – 2020');
     });
 

--- a/packages/react-calendar/src/Calendar.tsx
+++ b/packages/react-calendar/src/Calendar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import Navigation from './Calendar/Navigation.js';
@@ -669,6 +669,8 @@ const Calendar = forwardRef(function Calendar(props: CalendarProps, ref) {
         : null,
   );
   const [viewState, setViewState] = useState<View | undefined>(defaultView);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const setContentFocus = useRef(false);
 
   const activeStartDate =
     activeStartDateProps ||
@@ -800,6 +802,7 @@ const Calendar = forwardRef(function Calendar(props: CalendarProps, ref) {
 
       setActiveStartDateState(nextActiveStartDate);
       setViewState(nextView);
+      setContentFocus.current = true;
 
       const args: OnArgs = {
         action: 'drillDown',
@@ -1003,6 +1006,13 @@ const Calendar = forwardRef(function Calendar(props: CalendarProps, ref) {
     [activeStartDate, drillDown, drillUp, onChange, setActiveStartDate, value, view],
   );
 
+  useEffect(() => {
+    if (setContentFocus.current) {
+      setContentFocus.current = false;
+      contentRef.current?.focus();
+    }
+  });
+
   function renderContent(next?: boolean) {
     const currentActiveStartDate = next
       ? getBeginNext(view, activeStartDate)
@@ -1125,6 +1135,8 @@ const Calendar = forwardRef(function Calendar(props: CalendarProps, ref) {
         className={`${baseClassName}__viewContainer`}
         onBlur={selectRange ? onMouseLeave : undefined}
         onMouseLeave={selectRange ? onMouseLeave : undefined}
+        tabIndex={-1}
+        ref={contentRef}
       >
         {renderContent()}
         {showDoubleView ? renderContent(true) : null}


### PR DESCRIPTION
Currently when changing views (century, decade, year, etc) the focus goes to the body.

This PR ensures the focus stays within the view container when switching between views.

Before:

https://github.com/wojtekmaj/react-calendar/assets/697377/1bfd6935-b585-40b7-a95e-7f956633ebb8

After:

https://github.com/wojtekmaj/react-calendar/assets/697377/fb273856-548a-4d8e-abdf-1397f7b514ff

