### PR TITLE
Expose shared CalendarType type

### DIFF
--- a/packages/react-calendar/src/index.ts
+++ b/packages/react-calendar/src/index.ts
@@ -8,6 +8,7 @@ import YearView from './YearView.js';
 export type { CalendarProps } from './Calendar.js';
 
 export type {
+  CalendarType,
   NavigationLabelFunc,
   OnArgs,
   OnClickFunc,


### PR DESCRIPTION
Hello! 👋 

Firstly, thanks so much for your work on this package! I should probably have opened an issue about this but given it's such a small change I opted for a PR, apologies if that's not the done thing. We can close and take this to an issue if you prefer.

We have need of [CalendarType in the grafana codebase here](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx#L4). However I'm not a fan of these nested imports which, if we were to migrate to Vite, I'm pretty sure will fail as the file shared/types is not exported.

This PR simply adds the type we're using to the exports in index.ts to save us from accessing types that aren't (currently) public.