### PR TITLE
fix: use named export for clsx

### DIFF
--- a/packages/react-calendar/src/Calendar.tsx
+++ b/packages/react-calendar/src/Calendar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 
 import Navigation from './Calendar/Navigation.js';
 import CenturyView from './CenturyView.js';

--- a/packages/react-calendar/src/MonthView.tsx
+++ b/packages/react-calendar/src/MonthView.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 
 import Days from './MonthView/Days.js';
 import Weekdays from './MonthView/Weekdays.js';

--- a/packages/react-calendar/src/MonthView/Weekdays.tsx
+++ b/packages/react-calendar/src/MonthView/Weekdays.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { getYear, getMonth, getMonthStart } from '@wojtekmaj/date-utils';
 
 import Flex from '../Flex.js';

--- a/packages/react-calendar/src/Tile.tsx
+++ b/packages/react-calendar/src/Tile.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 
 import type {
   ClassName,


### PR DESCRIPTION
when using on rspack the default export with ESM does not translate well
![image](https://github.com/user-attachments/assets/3ebdc955-1477-482e-a9ab-e0fb5cea1a1a)
