### PR TITLE
feat(a11y): added WAI-ARIA role prop

### DIFF
--- a/packages/react-calendar/src/Calendar.tsx
+++ b/packages/react-calendar/src/Calendar.tsx
@@ -64,6 +64,12 @@ export type CalendarProps = {
    */
   allowPartialRange?: boolean;
   /**
+   * `aria-label` attribute of the calendar container.
+   *
+   * @example 'Calendar'
+   */
+  ariaLabel?: string;
+  /**
    * Type of calendar that should be used. Can be `'gregory`, `'hebrew'`, `'islamic'`, `'iso8601'`. Setting to `"gregory"` or `"hebrew"` will change the first day of the week to Sunday. Setting to `"islamic"` will change the first day of the week to Saturday. Setting to `"islamic"` or `"hebrew"` will make weekends appear on Friday to Saturday.
    *
    * @example 'iso8601'
@@ -609,6 +615,7 @@ const Calendar: React.ForwardRefExoticComponent<CalendarProps & React.RefAttribu
     const {
       activeStartDate: activeStartDateProps,
       allowPartialRange,
+      ariaLabel,
       calendarType,
       className,
       defaultActiveStartDate,
@@ -1133,6 +1140,7 @@ const Calendar: React.ForwardRefExoticComponent<CalendarProps & React.RefAttribu
         )}
         ref={inputRef}
         role={role}
+        aria-label={ariaLabel}
       >
         {renderNavigation()}
         <div

--- a/packages/react-calendar/src/Calendar.tsx
+++ b/packages/react-calendar/src/Calendar.tsx
@@ -329,6 +329,13 @@ export type CalendarProps = {
    */
   returnValue?: 'start' | 'end' | 'range';
   /**
+   * The WAI-ARIA role of the calendar.
+   *
+   * @default 'dialog'
+   * @example 'dialog'
+   */
+  role?: React.AriaRole;
+  /**
    * Whether the user shall select two dates forming a range instead of just one. **Note**: This feature will make react-calendar return array with two dates regardless of returnValue setting.
    *
    * @default false
@@ -643,6 +650,7 @@ const Calendar: React.ForwardRefExoticComponent<CalendarProps & React.RefAttribu
       prevAriaLabel,
       prevLabel,
       returnValue = 'start',
+      role = 'dialog',
       selectRange,
       showDoubleView,
       showFixedNumberOfWeeks,
@@ -1124,6 +1132,7 @@ const Calendar: React.ForwardRefExoticComponent<CalendarProps & React.RefAttribu
           className,
         )}
         ref={inputRef}
+        role={role}
       >
         {renderNavigation()}
         <div


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles

Because of the upcoming European accessibility act, I added:
- a role prop
- an aria label

to make the component easier accessible for screen readers.

Further references:
https://commission.europa.eu/strategy-and-policy/policies/justice-and-fundamental-rights/disability/union-equality-strategy-rights-persons-disabilities-2021-2030/european-accessibility-act_en